### PR TITLE
Cross-link the registrar and contacts endpoints

### DIFF
--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -77,9 +77,7 @@ Name | Type | Description
 `extended_attributes` | `hash` | **Required** for TLDs that require [extended attributes](/v2/tlds/#extended-attributes).
 
 <note>
-The `registrant_id` can be obtained via the [contacts endpoint](/v2/contacts) and will be the registered contact for this
-domain. It is named differently due to the domain registration context technically allowing a registrant, technical, and
-administrative contact. The API currently does not support multiple registrant types, but it may be supported in the future.
+The `registrant_id` can be obtained via the [contacts endpoint](/v2/contacts) and will be the registered contact for this domain.
 </note>
 
 ##### Example

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -76,6 +76,10 @@ Name | Type | Description
 `auto_renew` | `bool` | Set to true to enable the auto-renewal of the domain. Default: `true`.
 `extended_attributes` | `hash` | **Required** for TLDs that require [extended attributes](/v2/tlds/#extended-attributes).
 
+<note>
+The `registrant_id` can be obtained via the [contacts endpoint](/v2/contacts)
+</note>
+
 ##### Example
 
 ~~~json

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -77,7 +77,9 @@ Name | Type | Description
 `extended_attributes` | `hash` | **Required** for TLDs that require [extended attributes](/v2/tlds/#extended-attributes).
 
 <note>
-The `registrant_id` can be obtained via the [contacts endpoint](/v2/contacts)
+The `registrant_id` can be obtained via the [contacts endpoint](/v2/contacts) and will be the registered contact for this
+domain. It is named differently due to the domain registration context technically allowing a registrant, technical, and
+administrative contact. The API currently does not support multiple registrant types, but it may be supported in the future.
 </note>
 
 ##### Example


### PR DESCRIPTION
This is to address some customer confusion about where to obtain this id. It's not consistent in name. I would expect contact_id here instead of registrant_id, but I get why it's named in context for this endpoint.