### PR TITLE
Update preview of ddns.sh for API v2 changes

### DIFF
--- a/content/ddns.markdown
+++ b/content/ddns.markdown
@@ -13,19 +13,18 @@ Some DNS providers offer a proprietary tool to accomplish this and others even s
 
 ~~~bash
 #!/bin/bash
- 
-LOGIN="your@email"
-TOKEN="your-api-token"
-DOMAIN_ID="yourdomain.com"
-RECORD_ID="12345" # Replace with the Record ID
+
+TOKEN="your-oauth-token"  # The API v2 OAuth token
+ZONE_ID="yourdomain.com"  # The zone ID is the name of the zone (or domain)
+RECORD_ID="12345"         # Replace with the Record ID
 IP=`curl -s http://icanhazip.com/`
- 
-curl -H "Accept: application/json" \
+
+curl -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json" \
-     -H "X-DNSimple-Token: $LOGIN:$TOKEN" \
-     -X "PUT" \
-     -i "https://api.dnsimple.com/v1/domains/$DOMAIN_ID/records/$RECORD_ID" \
-     -d "{\"record\":{\"content\":\"$IP\"}}"
+     -H "Accept: application/json" \
+     -X "PATCH" \
+     -i "https://api.dnsimple.com/v2/zones/$ZONE_ID/records/$RECORD_ID" \
+     -d "{\"content\":\"$IP\"}"
 ~~~
 
 Download the shell script: [ddns.sh](ddns.sh)


### PR DESCRIPTION
ddns.sh is now different from the preview on the ddns page. This left me confused for a minute. I updated the web page to reflect the new ddns.sh file.