### PR TITLE
Update private_whois to whois_privacy

### DIFF
--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -128,7 +128,7 @@ Register the domain `example.com` in the account `1010`:
 Name | Type | Description
 -----|------|------------
 `registrant_id` | `integer` | **Required**. The ID of an existing contact in your account.
-`private_whois` | `bool` | Set to true to enable the whois privacy service. An extra cost may apply. Default: `false`.
+`whois_privacy` | `bool` | Set to true will attempt to purchase/enable the whois privacy as part of the registration. An extra cost may apply. Default: `false`.
 `auto_renew` | `bool` | Set to true to enable the auto-renewal of the domain. Default: `true`.
 `extended_attributes` | `hash` | **Required** for TLDs that require [extended attributes](/v2/tlds/#extended-attributes).
 `premium_price` | `string` | **Required** as confirmation of the price, only if the domain is premium.
@@ -194,7 +194,7 @@ Name | Type | Description
 -----|------|------------
 `registrant_id` | `integer` | **Required**. The ID of an existing contact in your account.
 `auth_code` | `string` | **Required** for TLDS that require authorization-based transfer (the vast majority of TLDs).
-`private_whois` | `bool` | Set to true to enable the whois privacy service. An extra cost may apply. Default: `false`.
+`whois_privacy` | `bool` | Set to true will attempt to purchase/enable the whois privacy as part of the transfer. An extra cost may apply. Default: `false`.
 `auto_renew` | `bool` | Set to true to enable the auto-renewal of the domain. Default: `true`.
 `extended_attributes` | `hash` | **Required** for TLDs that require [extended attributes](/v2/tlds/#extended-attributes).
 `premium_price` | `string` | **Required** as confirmation of the price, only if the domain is premium.

--- a/fixtures/v2/registerDomain/success.http
+++ b/fixtures/v2/registerDomain/success.http
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"registrant_id":2,"period":1,"state":"new","auto_renew":false,"private_whois":false,"premium_price":null,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"period":1,"state":"new","auto_renew":false,"whois_privacy":false,"premium_price":null,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}

--- a/fixtures/v2/renewDomain/success.http
+++ b/fixtures/v2/renewDomain/success.http
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"period":1,"state":"new","private_whois":false,"premium_price":null,"created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}
+{"data":{"id":1,"domain_id":999,"period":1,"state":"new","premium_price":null,"created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}

--- a/fixtures/v2/transferDomain/success.http
+++ b/fixtures/v2/transferDomain/success.http
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"registrant_id":2,"state":"transferring","auto_renew":false,"private_whois":false,"premium_price":null,"created_at":"2016-12-09T19:43:41Z","updated_at":"2016-12-09T19:43:43Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"created_at":"2016-12-09T19:43:41Z","updated_at":"2016-12-09T19:43:43Z"}}


### PR DESCRIPTION
This change was discussed between @jacegu @jodosha @weppos
and it is the result of reducing potential confusion especially now
that these methods return registrar orders.