### PR TITLE
update some urls to point to the new repository

### DIFF
--- a/layouts/sidebar.html
+++ b/layouts/sidebar.html
@@ -14,6 +14,6 @@
 
 <div class="sidebar-infobox well">
   Want to make these docs better?
-  <a href="https://github.com/aetrion/developer.dnsimple.com">Fork our repo</a>,
-  make your changes and <a href="https://github.com/aetrion/developer.dnsimple.com/issues">submit a hug request</a>.
+  <a href="https://github.com/dnsimple/dnsimple-developer">Fork our repo</a>,
+  make your changes and <a href="https://github.com/dnsimple/dnsimple-developer/issues">submit a hug request</a>.
 </div>

--- a/layouts/v1-sidebar.html
+++ b/layouts/v1-sidebar.html
@@ -47,6 +47,6 @@
 
 <div class="sidebar-infobox well">
   Want to make these docs better?
-  <a href="https://github.com/aetrion/developer.dnsimple.com">Fork our repo</a>,
-  make your changes and <a href="https://github.com/aetrion/developer.dnsimple.com/issues">submit a hug request</a>.
+  <a href="https://github.com/dnsimple/dnsimple-developer">Fork our repo</a>,
+  make your changes and <a href="https://github.com/dnsimple/dnsimple-developer/issues">submit a hug request</a>.
 </div>

--- a/layouts/v2-sidebar.html
+++ b/layouts/v2-sidebar.html
@@ -48,6 +48,6 @@
 
 <div class="sidebar-infobox well">
   Want to make these docs better?
-  <a href="https://github.com/aetrion/developer.dnsimple.com">Fork our repo</a>,
-  make your changes and <a href="https://github.com/aetrion/developer.dnsimple.com/issues">submit a hug request</a>.
+  <a href="https://github.com/dnsimple/dnsimple-developer">Fork our repo</a>,
+  make your changes and <a href="https://github.com/dnsimple/dnsimple-developer/issues">submit a hug request</a>.
 </div>


### PR DESCRIPTION
The repository for developer.dnsimple.com is now
on github.com/dnsimple/dnsimple-developer.