### PR TITLE
update the link to nanoc website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DNSimple API Documentation
 
-This is the DNSimple API documentation built with [nanoc](http://nanoc.stoneship.org/).
+This is the DNSimple API documentation built with [nanoc](http://nanoc.ws/).
 
 ## Setup
 


### PR DESCRIPTION
The old one to stoneship.org is not resolving anymore.