### PR TITLE
DDNS: Request ipv4 address by default.

### DIFF
--- a/content/ddns.markdown
+++ b/content/ddns.markdown
@@ -18,7 +18,7 @@ TOKEN="your-oauth-token"  # The API v2 OAuth token
 ACCOUNT\_ID="12345"        # Replace with your account ID
 ZONE\_ID="yourdomain.com"  # The zone ID is the name of the zone (or domain)
 RECORD\_ID="1234567"       # Replace with the Record ID
-IP=`curl -s http://icanhazip.com/`
+IP=`curl --ipv4 -s http://icanhazip.com/`
 
 curl -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json" \

--- a/content/ddns/ddns.sh
+++ b/content/ddns/ddns.sh
@@ -4,7 +4,7 @@ TOKEN="your-oauth-token"  # The API v2 OAuth token
 ACCOUNT_ID="12345"        # Replace with your account ID
 ZONE_ID="yourdomain.com"  # The zone ID is the name of the zone (or domain)
 RECORD_ID="1234567"       # Replace with the Record ID
-IP=`curl -s http://icanhazip.com/`
+IP=`curl --ipv4 -s http://icanhazip.com/`
 
 curl -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json" \


### PR DESCRIPTION
When ipv6 and ipv4 are available for the given connection by default
ipv4 should be preferred, as most users will probably be interested to
update their ipv4 addresses.

There are two ways to accomplish this, either use the ipv4 subdomain
'ipv4.icanhazip.com' or force curl to resolve to ipv4 address. The
recommended way described in the FAQs
(https://major.io/icanhazip-com-faq/) is to use the command-line
options, which this change implements.