### PR TITLE
URL is not taken from the request body, rather from a collection of registered URLs

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1847,7 +1847,7 @@ components:
   links: {}
   callbacks:
     webhook:
-      '$request.body#/url':
+      '$webhookUrl':
         post:
           requestBody:
             description: The webhook payload


### PR DESCRIPTION
After reading the spec during the advanced OpenAPI 3 workshop, I believe this change better documents how our system works.