### PR TITLE
add minimum_registration to components/schemas/TLD

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3751,6 +3751,9 @@ components:
         idn:
           type: boolean
           description: true if the suffix supports Internationalized Domain Names (IDN).
+        minimum_registration:
+          type: integer
+          description: The minimum registration period, in years.
         registration_enabled:
           type: boolean
           description: true if DNSimple supports registrations for this TLD.


### PR DESCRIPTION
This was missing from the schema, but exists in the example, and is actually
used in the sandbox and prod api.
