### PR TITLE
Fix Semantic error Schemas with 'type: array', require 'items'

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2088,7 +2088,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2103,7 +2103,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2118,7 +2118,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2133,7 +2133,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2146,7 +2146,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2161,7 +2161,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2174,7 +2174,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2189,7 +2189,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2206,7 +2206,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'tld:asc'
           - 'tld:desc'
@@ -2217,7 +2217,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2228,7 +2228,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'
@@ -2241,7 +2241,7 @@ components:
       in: query
       required: false
       schema:
-        type: array
+        type: string
         enum:
           - 'id:asc'
           - 'id:desc'


### PR DESCRIPTION
Fixes the error:

> Semantic error at components.parameters.SortDelegationSignerRecords.schema
> Schemas with 'type: array', require a sibling 'items: ' field
> Jump to line 2135

![Screenshot 2019-08-02 at 19 10 37](https://user-images.githubusercontent.com/5387/62387152-24c3b300-b55a-11e9-8764-083e4aa522de.png)

Actually, we allow to use any of those enums, of combination of them separated by comma. But there's no way to define it in the schema, so I'm just setting it as enum as I think was originally the plan.

![Screenshot 2019-08-02 at 19 18 15](https://user-images.githubusercontent.com/5387/62387217-4de44380-b55a-11e9-9b3a-e55d900e4021.png)
