### PR TITLE
Remove documentation of deprecated domain.token_reset event

### DIFF
--- a/content/v2/domains.markdown
+++ b/content/v2/domains.markdown
@@ -199,10 +199,3 @@ Delete the domain `example.com` in the account `1010`:
 ### Response
 
 Responds with HTTP 204 on success.
-
-
-## Reset a domain token {#resetDomainToken}
-
-<note>
-This method has been removed. The domain token is no longer supported in API v2.
-</note>

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3052,12 +3052,6 @@ components:
       properties:
         domain:
           $ref: '#/components/schemas/Domain'
-    EventDomainTokenReset:
-      type: object
-      description: Payload for domain.token_reset
-      properties:
-        domain:
-          $ref: '#/components/schemas/Domain'
     EventDomainTransfer:
       type: object
       description: Payload for domain.transfer
@@ -3860,7 +3854,6 @@ components:
             - domain.registrant_change
             - domain.resolution_disable
             - domain.resolution_enable
-            - domain.token_reset
             - 'domain.transfer:started'
             - domain.transfer
             - email_forward.create
@@ -3950,7 +3943,6 @@ components:
             - $ref: '#/components/schemas/EventDomainRegistrantChange'
             - $ref: '#/components/schemas/EventDomainResolutionDisable'
             - $ref: '#/components/schemas/EventDomainResolutionEnable'
-            - $ref: '#/components/schemas/EventDomainTokenReset'
             - $ref: '#/components/schemas/EventDomainTransfer'
             - $ref: '#/components/schemas/EventEmailForwardCreate'
             - $ref: '#/components/schemas/EventEmailForwardDelete'

--- a/content/v2/webhooks.markdown
+++ b/content/v2/webhooks.markdown
@@ -91,7 +91,6 @@ The following events are available:
 - domain.registrant\_change
 - domain.resolution\_disable
 - domain.resolution\_enable
-- domain.token\_reset
 - domain.transfer:started
 - domain.transfer
 - email\_forward.create


### PR DESCRIPTION
The method is no longer in use and has no effect in API v2.