### PR TITLE
Include link to example payloads

### DIFF
--- a/content/v2/webhooks.markdown
+++ b/content/v2/webhooks.markdown
@@ -132,7 +132,7 @@ The following events are available:
 
 ### Event payloads
 
-We maintain a repository of example payloads that you can use [here](https://github.com/dnsimple/dnsimple-developer/tree/master/fixtures/v2/webhooks).
+We maintain a [repository of example payloads](https://github.com/dnsimple/dnsimple-developer/tree/master/fixtures/v2/webhooks) that you can use to design and test your integrations.
 
 ## List webhooks {#list}
 

--- a/content/v2/webhooks.markdown
+++ b/content/v2/webhooks.markdown
@@ -130,6 +130,9 @@ The following events are available:
 - zone\_record.delete
 - zone\_record.update
 
+### Event payloads
+
+We maintain a repository of example payloads that you can use [here](https://github.com/dnsimple/dnsimple-developer/tree/master/fixtures/v2/webhooks).
 
 ## List webhooks {#list}
 


### PR DESCRIPTION
Since we maintain a collection of fixtures for each webhook event and these are a valuable resource for customers using our API I think it's worth it to link them from the corresponding docs.