### PR TITLE
Update redirects to eliminate 404s

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -82,7 +82,7 @@ redirects:
   v1/domains: /v2/domains/
   v1/nameservers/vanity-nameservers: https://support.dnsimple.com/articles/vanity-nameservers/
   v1/nameservers: /v2/
-  v1/planned-changes index.html: /
+  v1/planned-changes: /
   v1/registrar/auto-renewal: /v2/registrar/auto-renewal/
   v1/registrar/extended-attributes: /v2/registrar/
   v1/registrar/prices: /v2/registrar/

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,6 +1,6 @@
 s3_id: <%= ENV['S3_ID'] %>
 s3_secret: <%= ENV['S3_SECRET'] %>
-s3_bucket: developer.dnsimple.com 
+s3_bucket: developer.dnsimple.com
 cloudfront_distribution_id: E3LNNGWSVTJ7BP
 
 # Below are examples of all the available configurations.
@@ -19,7 +19,7 @@ site: output
 # gzip_zopfli: true
 
 # See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region for valid endpoints
-s3_endpoint: us-west-2 
+s3_endpoint: us-west-2
 
 # ignore_on_server: that_folder_of_stuff_i_dont_keep_locally
 
@@ -44,30 +44,63 @@ cloudfront_distribution_config:
 # concurrency_level: 5
 
 redirects:
-  authentication/index.html: /v1/authentication/
-  certificates/index.html: /v1/certificates/
-  contacts/index.html: /v1/contacts/
-  domains/autorenewal/index.html: /v1/domains/autorenewal/
-  domains/forwards/index.html: /v1/domains/forwards/
-  domains/privacy/index.html: /v1/domains/privacy/
-  domains/records/index.html: /v1/domains/records/
-  domains/sharing/index.html: /v1/domains/sharing/
-  domains/zones/index.html: /v1/domains/zones/
-  domains/index.html: /v1/domains/
-  nameservers/vanity-nameservers/index.html: /v1/nameservers/vanity-nameservers/
-  nameservers/index.html: /v1/nameservers/
-  overview/index.html: /v1/
-  planned-changes/index.html: /v1/planned-changes/index.html
-  registrar/extended-attributes/index.html: /v1/registrar/extended-attributes/
-  registrar/prices/index.html: /v1/registrar/prices/
-  registrar/index.html: /v1/registrar/
-  services/domains/index.html: /v1/services/domains/
-  services/index.html: /v1/services/
-  subscriptions/index.html: /v1/subscriptions/
-  templates/domains/index.html: /v1/templates/domains/
-  templates/records/index.html: /v1/templates/records/
-  templates/index.html: /v1/templates/
-  users/index.html: /v1/users/
+  138: /
+  authentication: /v2/#authentication
+  certificates: /v1/certificates/
+  contacts: /v2/contacts/
+  domains/autorenewal: /v2/registrar/auto-renewal/
+  domains/forwards: /v1/domains/forwards/
+  domains/privacy: /v1/domains/privacy/
+  domains/records: /v2/zones/records/
+  domains/registry: /v2/domains/
+  domains/sharing: /v1/domains/sharing/
+  domains/zones: /v2/zones/
+  domains: /v1/domains/
+  nameservers/vanity-nameservers: /v1/nameservers/vanity-nameservers/
+  nameservers: /v1/nameservers/
+  OptionsNote: /
+  overview: /
+  planned-changes: /
+  registrar/autorenewal: /v2/registrar/auto-renewal/
+  registrar/extended-attributes: /v1/registrar/extended-attributes/
+  registrar/prices: /v1/registrar/prices/
+  registrar: /v2/registrar/
+  Requirements: /
+  services/domains: /v1/services/domains/
+  services: /v1/services/
+  subscriptions: /v1/subscriptions/
+  templates/domains: /v1/templates/domains/
+  templates/records: /v1/templates/records/
+  templates: /v1/templates/
+  users: /v1/users/
+  v1/certificates: /v2/certificates/
+  v1/contacts: /v2/contacts/
+  v1/domains/forwards: /v2/domains/email-forwards/
+  v1/domains/records: /v2/zones/records/
+  v1/domains/sharing: /v2/domains/
+  v1/domains/zones: /v2/zones/
+  v1/domains: /v2/domains/
+  v1/nameservers/vanity-nameservers: https://support.dnsimple.com/articles/vanity-nameservers/
+  v1/nameservers: /v2/
+  v1/planned-changes index.html: /
+  v1/registrar/auto-renewal: /v2/registrar/auto-renewal/
+  v1/registrar/extended-attributes: /v2/registrar/
+  v1/registrar/prices: /v2/registrar/
+  v1/registrar/privacy: /v2/registrar/whois-privacy/
+  v1/registrar: /v2/registrar/
+  v1/services/domains: /v2/services/domains/
+  v1/services: /v2/services/
+  v1/subscriptions: /v2/
+  v1/templates/domains: /v2/templates/domains/
+  v1/templates/records: /v2/templates/records/
+  v1/templates: /v2/templates/
+  v1/users: https://support.dnsimple.com/articles/account-users/
+  v1: /v2/
+  v2/changelog: /v2/
+  v2/domains/certificates: /v2/domains/
+  v2/domains/templates: /v2/domains/
+  v2/pushes: /v2/domains/pushes/
+  v2/whoami: /v2/
 
 # routing_rules:
 #   - condition:

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -44,35 +44,33 @@ cloudfront_distribution_config:
 # concurrency_level: 5
 
 redirects:
-  138: /
-  authentication: /v2/#authentication
-  certificates: /v1/certificates/
+  authentication: /v2/oauth/
+  certificates: /v2/certificates/
   contacts: /v2/contacts/
   domains/autorenewal: /v2/registrar/auto-renewal/
-  domains/forwards: /v1/domains/forwards/
-  domains/privacy: /v1/domains/privacy/
+  domains/forwards: /v2/domains/
+  domains/privacy: /v2/domains/
   domains/records: /v2/zones/records/
   domains/registry: /v2/domains/
-  domains/sharing: /v1/domains/sharing/
+  domains/sharing: /v2/domains/
   domains/zones: /v2/zones/
-  domains: /v1/domains/
-  nameservers/vanity-nameservers: /v1/nameservers/vanity-nameservers/
-  nameservers: /v1/nameservers/
-  OptionsNote: /
+  domains: /v2/domains/
+  nameservers/vanity-nameservers: /v2/vanity/
+  nameservers: /v2/vanity/
   overview: /
   planned-changes: /
-  registrar/autorenewal: /v2/registrar/auto-renewal/
-  registrar/extended-attributes: /v1/registrar/extended-attributes/
-  registrar/prices: /v1/registrar/prices/
+  registrar/autorenewal: /v2/registrar/
+  registrar/extended-attributes: /v2/registrar/
+  registrar/prices: /v2/registrar/
   registrar: /v2/registrar/
   Requirements: /
-  services/domains: /v1/services/domains/
-  services: /v1/services/
-  subscriptions: /v1/subscriptions/
-  templates/domains: /v1/templates/domains/
-  templates/records: /v1/templates/records/
-  templates: /v1/templates/
-  users: /v1/users/
+  services/domains: /v2/services/
+  services: /v2/services/
+  subscriptions: /
+  templates/domains: /v2/templates/
+  templates/records: /v2/templates/
+  templates: /v2/templates/
+  users: /v2/oauth/
   v1/certificates: /v2/certificates/
   v1/contacts: /v2/contacts/
   v1/domains/forwards: /v2/domains/email-forwards/
@@ -80,7 +78,7 @@ redirects:
   v1/domains/sharing: /v2/domains/
   v1/domains/zones: /v2/zones/
   v1/domains: /v2/domains/
-  v1/nameservers/vanity-nameservers: https://support.dnsimple.com/articles/vanity-nameservers/
+  v1/nameservers/vanity-nameservers: /v2/vanity/
   v1/nameservers: /v2/
   v1/planned-changes: /
   v1/registrar/auto-renewal: /v2/registrar/auto-renewal/
@@ -100,7 +98,7 @@ redirects:
   v2/domains/certificates: /v2/domains/
   v2/domains/templates: /v2/domains/
   v2/pushes: /v2/domains/pushes/
-  v2/whoami: /v2/
+  v2/whoami: /v2/identity/
 
 # routing_rules:
 #   - condition:


### PR DESCRIPTION
As per: https://docs.google.com/spreadsheets/d/1t8Qv6N-Iof-URt28N4cFOgABs5uHxMQwJMLpE4YeGhA/edit#gid=77343041

Removed `/index.html` from the keys to allow S3 to do its thing:
- https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html
- https://github.com/laurilehmijoki/s3_website

## Verification

- [ ] `/registrar/autorenewal` should redirect to `/v2/registrar/auto-renewal/`
- [ ] `/registrar/autorenewal/` should redirect to `/v2/registrar/auto-renewal/`
- [ ] `/registrar/autorenewal/index.html` should redirect to `/v2/registrar/auto-renewal/`