### PR TITLE
Add domain states enum to openapi YAML

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2642,6 +2642,10 @@ components:
           type: string
         state:
           type: string
+          enum:
+            - hosted
+            - registered
+            - expired
         auto_renew:
           type: boolean
         private_whois:


### PR DESCRIPTION
The list of domain states was not present in the Domain schema. This adds the states.