### PR TITLE
Fixes check for invalid content

### DIFF
--- a/_test/content_test.rb
+++ b/_test/content_test.rb
@@ -16,7 +16,7 @@ describe "Content" do
     regexp   = /[#{BannedCharacters.join}]/
     affected = []
 
-    Dir["content/*"].each do |path| 
+    Dir["content/**/*.markdown"].each do |path|
       next unless File.file?(path)
       File.readlines(path).each do |line|
         affected << [path, line] if regexp.match(line)


### PR DESCRIPTION
Fixes #233

This PR recursively look for markdown files under the content directory and check for invalid characters.