### PR TITLE
Replace cancelDomainTransfer and getDomainTransfer fixtures

### DIFF
--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -259,12 +259,12 @@ Name | Type | Description
 
 ### Example
 
-Get the domain transfer with ID `1` in the account `1010`:
+Get the domain transfer with ID `358` in the account `1010`:
 
 ~~~
 curl  -H 'Authorization: Bearer <token>' \
       -H 'Accept: application/json' \
-      https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/1
+      https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/358
 ~~~
 
 ### Response
@@ -294,13 +294,13 @@ Name | Type | Description
 
 ### Example
 
-Cancel the in progress domain transfer with ID `1` in the account `1010`:
+Cancel the in progress domain transfer with ID `358` in the account `1010`:
 
 ~~~
 curl  -H 'Authorization: Bearer <token>' \
       -H 'Accept: application/json' \
       -X DELETE \
-      https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/1
+      https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/358
 ~~~
 
 ### Response

--- a/fixtures/v2/api/cancelDomainTransfer/success.http
+++ b/fixtures/v2/api/cancelDomainTransfer/success.http
@@ -1,17 +1,19 @@
-HTTP/2 202 
-server: nginx
-date: Mon, 18 May 2020 14:02:58 GMT
-content-type: application/json; charset=utf-8
-x-ratelimit-limit: 2400
-x-ratelimit-remaining: 2393
-x-ratelimit-reset: 1589813834
-cache-control: no-cache
-x-request-id: 98a59035-27c8-421e-b357-127f4c8da4e0
-x-runtime: 1.144313
-x-frame-options: DENY
-x-content-type-options: nosniff
-x-xss-protection: 1; mode=block
-x-download-options: noopen
-x-permitted-cross-domain-policies: none
+HTTP/1.1 202 Accepted
+Server: nginx
+Date: Mon, 18 May 2020 16:55:35 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1589824450
+Cache-Control: no-cache
+X-Request-Id: c9ecfbd2-3db4-4550-a6d6-8dd9f5b68a06
+X-Runtime: 0.905412
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 
-{"data":{"id":357,"domain_id":180716,"registrant_id":2459,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":null,"created_at":"2020-05-18T14:01:39Z","updated_at":"2020-05-18T14:01:47Z"}}
+{"data":{"id":358,"domain_id":180716,"registrant_id":2459,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":null,"created_at":"2020-05-18T16:54:15Z","updated_at":"2020-05-18T16:54:22Z"}}

--- a/fixtures/v2/api/cancelDomainTransfer/success.http
+++ b/fixtures/v2/api/cancelDomainTransfer/success.http
@@ -1,17 +1,17 @@
 HTTP/2 202 
 server: nginx
-date: Fri, 15 May 2020 23:32:18 GMT
+date: Mon, 18 May 2020 14:02:58 GMT
 content-type: application/json; charset=utf-8
 x-ratelimit-limit: 2400
-x-ratelimit-remaining: 2398
-x-ratelimit-reset: 1589589107
+x-ratelimit-remaining: 2393
+x-ratelimit-reset: 1589813834
 cache-control: no-cache
-x-request-id: 7ae323e9-fc40-4557-979d-46dadb6ac9e8
-x-runtime: 0.537101
+x-request-id: 98a59035-27c8-421e-b357-127f4c8da4e0
+x-runtime: 1.144313
 x-frame-options: DENY
 x-content-type-options: nosniff
 x-xss-protection: 1; mode=block
 x-download-options: noopen
 x-permitted-cross-domain-policies: none
 
-{"data":{"id":41438,"domain_id":584791,"registrant_id":45395,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":null,"created_at":"2020-05-15T23:31:49Z","updated_at":"2020-05-15T23:31:51Z"}}
+{"data":{"id":357,"domain_id":180716,"registrant_id":2459,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":null,"created_at":"2020-05-18T14:01:39Z","updated_at":"2020-05-18T14:01:47Z"}}

--- a/fixtures/v2/api/cancelDomainTransfer/success.http
+++ b/fixtures/v2/api/cancelDomainTransfer/success.http
@@ -1,30 +1,17 @@
-HTTP/1.1 202 Accepted
-Server: nginx
-Date: Wed, 29 Apr 2020 19:49:41 GMT
-Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
-Connection: keep-alive
-Status: 202 Accepted
-X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2397
-X-RateLimit-Reset: 1588193270
-ETag: W/"8404bf2739e44e9f69f3a5199466776d"
-Cache-Control: no-store, must-revalidate, private, max-age=0
-X-Request-Id: 10d75bcf-0066-4d38-98a2-dc18dd5b6f4c
-X-Runtime: 1.752154
-Strict-Transport-Security: max-age=31536000
+HTTP/2 202 
+server: nginx
+date: Fri, 15 May 2020 23:32:18 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2398
+x-ratelimit-reset: 1589589107
+cache-control: no-cache
+x-request-id: 7ae323e9-fc40-4557-979d-46dadb6ac9e8
+x-runtime: 0.537101
+x-frame-options: DENY
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+x-download-options: noopen
+x-permitted-cross-domain-policies: none
 
-{
-  "data": {
-    "id": 5,
-    "domain_id": 5,
-    "registrant_id": 1,
-    "state": "transferring",
-    "auto_renew": true,
-    "whois_privacy": false,
-    "premium_price": null,
-    "status_description": null,
-    "created_at": "2020-04-24T19:19:03Z",
-    "updated_at": "2020-04-24T19:19:15Z"
-  }
-}
+{"data":{"id":41438,"domain_id":584791,"registrant_id":45395,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":null,"created_at":"2020-05-15T23:31:49Z","updated_at":"2020-05-15T23:31:51Z"}}

--- a/fixtures/v2/api/getDomainTransfer/success.http
+++ b/fixtures/v2/api/getDomainTransfer/success.http
@@ -1,19 +1,21 @@
-HTTP/2 200 
-server: nginx
-date: Mon, 18 May 2020 14:10:58 GMT
-content-type: application/json; charset=utf-8
-x-ratelimit-limit: 2400
-x-ratelimit-remaining: 2386
-x-ratelimit-reset: 1589813835
-etag: W/"aff08d0d50a84631ff9e0a27853b6f11"
-cache-control: max-age=0, private, must-revalidate
-x-request-id: 2904ae28-a562-41a1-8858-db0676f12081
-x-runtime: 0.082581
-x-frame-options: DENY
-x-content-type-options: nosniff
-x-xss-protection: 1; mode=block
-x-download-options: noopen
-x-permitted-cross-domain-policies: none
-strict-transport-security: max-age=31536000
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 18 May 2020 17:03:54 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2396
+X-RateLimit-Reset: 1589824450
+ETag: W/"9f81d47057f629dd921ccabff433ccac"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 7af4e96b-471d-4619-a0b6-b5d0d7261e75
+X-Runtime: 0.060273
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":357,"domain_id":180716,"registrant_id":2459,"state":"cancelled","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":"Canceled by customer","created_at":"2020-05-18T14:01:39Z","updated_at":"2020-05-18T14:10:01Z"}}
+{"data":{"id":358,"domain_id":180716,"registrant_id":2459,"state":"cancelled","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":"Canceled by customer","created_at":"2020-05-18T16:54:15Z","updated_at":"2020-05-18T17:00:02Z"}}

--- a/fixtures/v2/api/getDomainTransfer/success.http
+++ b/fixtures/v2/api/getDomainTransfer/success.http
@@ -1,14 +1,14 @@
 HTTP/2 200 
 server: nginx
-date: Fri, 15 May 2020 23:33:46 GMT
+date: Mon, 18 May 2020 14:10:58 GMT
 content-type: application/json; charset=utf-8
 x-ratelimit-limit: 2400
-x-ratelimit-remaining: 2396
-x-ratelimit-reset: 1589589107
-etag: W/"23c9e27495ac10625dfe85be57908c04"
+x-ratelimit-remaining: 2386
+x-ratelimit-reset: 1589813835
+etag: W/"aff08d0d50a84631ff9e0a27853b6f11"
 cache-control: max-age=0, private, must-revalidate
-x-request-id: 87655a2f-4cbb-41d4-87a1-6df62b934020
-x-runtime: 0.035200
+x-request-id: 2904ae28-a562-41a1-8858-db0676f12081
+x-runtime: 0.082581
 x-frame-options: DENY
 x-content-type-options: nosniff
 x-xss-protection: 1; mode=block
@@ -16,4 +16,4 @@ x-download-options: noopen
 x-permitted-cross-domain-policies: none
 strict-transport-security: max-age=31536000
 
-{"data":{"id":41373,"domain_id":583703,"registrant_id":45395,"state":"failed","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":"The status of test.ac prohibits the domain transfer (domain is locked at current registrar)","created_at":"2020-05-12T15:07:30Z","updated_at":"2020-05-12T15:07:33Z"}}
+{"data":{"id":357,"domain_id":180716,"registrant_id":2459,"state":"cancelled","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":"Canceled by customer","created_at":"2020-05-18T14:01:39Z","updated_at":"2020-05-18T14:10:01Z"}}

--- a/fixtures/v2/api/getDomainTransfer/success.http
+++ b/fixtures/v2/api/getDomainTransfer/success.http
@@ -1,30 +1,19 @@
-HTTP/1.1 200 OK
-Server: nginx
-Date: Mon, 27 Apr 2020 19:40:00 GMT
-Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
-Connection: keep-alive
-Status: 200 OK
-X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2398
-X-RateLimit-Reset: 1588019949
-ETag: W/"8404bf2739e44e9f69f3a5199466776d"
-Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 4818d867-1f72-4619-ab46-d345e6dd25eb
-X-Runtime: 0.092854
-Strict-Transport-Security: max-age=31536000
+HTTP/2 200 
+server: nginx
+date: Fri, 15 May 2020 23:33:46 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2396
+x-ratelimit-reset: 1589589107
+etag: W/"23c9e27495ac10625dfe85be57908c04"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 87655a2f-4cbb-41d4-87a1-6df62b934020
+x-runtime: 0.035200
+x-frame-options: DENY
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+x-download-options: noopen
+x-permitted-cross-domain-policies: none
+strict-transport-security: max-age=31536000
 
-{
-  "data": {
-    "id": 1,
-    "domain_id": 1,
-    "registrant_id": 1,
-    "state": "cancelled",
-    "auto_renew": false,
-    "whois_privacy": false,
-    "premium_price": null,
-    "status_description": "Canceled by customer",
-    "created_at": "2020-04-27T18:08:44Z",
-    "updated_at": "2020-04-27T18:20:01Z"
-  }
-}
+{"data":{"id":41373,"domain_id":583703,"registrant_id":45395,"state":"failed","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":"The status of test.ac prohibits the domain transfer (domain is locked at current registrar)","created_at":"2020-05-12T15:07:30Z","updated_at":"2020-05-12T15:07:33Z"}}

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -1,8 +1,6 @@
 require 'net/http'
 require 'json'
 
-
-
 include Nanoc::Helpers::Rendering
 include Nanoc::Helpers::XMLSitemap
 

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -4,20 +4,6 @@ require 'json'
 include Nanoc::Helpers::Rendering
 include Nanoc::Helpers::XMLSitemap
 
-# TODO: Remove this monkey-patch if https://github.com/ruby/ruby/pull/3117 get merged.
-module Net
-  class HTTPResponse
-    class << self
-      def read_status_line(sock)
-        str = sock.readline
-        m = /\AHTTP(?:\/(\d+\.?\d*))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
-          raise Net::HTTPBadResponse, "wrong status line: #{str.dump}"
-        m.captures
-      end
-    end
-  end
-end
-
 ROOT = File.expand_path("../../", __FILE__)
 
 def read_http_fixture(filename)

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -1,9 +1,24 @@
 require 'net/http'
 require 'json'
 
+
+
 include Nanoc::Helpers::Rendering
 include Nanoc::Helpers::XMLSitemap
 
+# TODO: Remove this monkey-patch if https://github.com/ruby/ruby/pull/3117 get merged.
+module Net
+  class HTTPResponse
+    class << self
+      def read_status_line(sock)
+        str = sock.readline
+        m = /\AHTTP(?:\/(\d+\.?\d*))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
+          raise Net::HTTPBadResponse, "wrong status line: #{str.dump}"
+        m.captures
+      end
+    end
+  end
+end
 
 ROOT = File.expand_path("../../", __FILE__)
 


### PR DESCRIPTION
getDomainTransfer and cancelDomainTransfer fixtures are not in the same
pattern as the other fixtures. This commit replaces them to be in the
same format as the others.