### PR TITLE
Fix Transfer-Encoding header in API fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ Finally, run:
 ```shell
 rake publish
 ```
+
+## Creating new fixtures
+
+- Use the sandbox API. Avoid using the production API as much as possible.
+- Run `bin/download_fixture.sh YOUR_TOKEN HTTP_METHOD URL > fixtures/v2/api/OPERATION/meaningful_name.http`
+
+  Example: `bin/download_fixture.sh 0123456789abcdefghijklmnopqrstuv GET https://api.sandbox.dnsimple.com/v2/tlds > fixtures/v2/api/listTlds/success.http`

--- a/bin/download_fixture.sh
+++ b/bin/download_fixture.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+curl -s \
+  -i \
+  --http1.1 \
+  -H "Authorization: Bearer $1" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -X $2 \
+  $3 |
+  sed 's/^Transfer-Encoding: chunked/Transfer-Encoding: identity/'

--- a/fixtures/v2/api/accounts/success-account.http
+++ b/fixtures/v2/api/accounts/success-account.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:02:58 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2391

--- a/fixtures/v2/api/accounts/success-user.http
+++ b/fixtures/v2/api/accounts/success-user.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:05:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2390

--- a/fixtures/v2/api/addCollaborator/invite-success.http
+++ b/fixtures/v2/api/addCollaborator/invite-success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 07 Oct 2016 08:51:12 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/addCollaborator/success.http
+++ b/fixtures/v2/api/addCollaborator/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 07 Oct 2016 08:53:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/fixtures/v2/api/appliedServices/success.http
+++ b/fixtures/v2/api/appliedServices/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 15 Jun 2016 11:09:44 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/cancelDomainTransfer/success.http
+++ b/fixtures/v2/api/cancelDomainTransfer/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 202 Accepted
 Server: nginx
 Date: Mon, 18 May 2020 16:55:35 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/changeDomainDelegation/success.http
+++ b/fixtures/v2/api/changeDomainDelegation/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:17:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/changeDomainDelegationToVanity/success.http
+++ b/fixtures/v2/api/changeDomainDelegationToVanity/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 11 Jul 2016 09:40:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/checkDomain/success.http
+++ b/fixtures/v2/api/checkDomain/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 26 Feb 2016 16:04:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/checkZoneDistribution/error.http
+++ b/fixtures/v2/api/checkZoneDistribution/error.http
@@ -2,7 +2,7 @@ HTTP/1.1 504 Gateway Timeout
 Server: nginx
 Date: Mon, 30 Oct 2017 09:09:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/checkZoneDistribution/failure.http
+++ b/fixtures/v2/api/checkZoneDistribution/failure.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 30 Oct 2017 09:09:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/checkZoneDistribution/success.http
+++ b/fixtures/v2/api/checkZoneDistribution/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 30 Oct 2017 09:09:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/checkZoneRecordDistribution/error.http
+++ b/fixtures/v2/api/checkZoneRecordDistribution/error.http
@@ -2,7 +2,7 @@ HTTP/1.1 504 Gateway Timeout
 Server: nginx
 Date: Mon, 18 Dec 2017 10:54:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/fixtures/v2/api/checkZoneRecordDistribution/failure.http
+++ b/fixtures/v2/api/checkZoneRecordDistribution/failure.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 18 Dec 2017 10:54:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/checkZoneRecordDistribution/success.http
+++ b/fixtures/v2/api/checkZoneRecordDistribution/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 18 Dec 2017 10:48:06 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/createContact/created.http
+++ b/fixtures/v2/api/createContact/created.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Tue, 19 Jan 2016 20:50:26 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/createDelegationSignerRecord/created.http
+++ b/fixtures/v2/api/createDelegationSignerRecord/created.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 03 Mar 2017 15:24:00 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/createDelegationSignerRecord/validation-error.http
+++ b/fixtures/v2/api/createDelegationSignerRecord/validation-error.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Fri, 03 Mar 2017 15:20:28 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395

--- a/fixtures/v2/api/createDomain/created.http
+++ b/fixtures/v2/api/createDomain/created.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 18 Dec 2015 16:38:07 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3986

--- a/fixtures/v2/api/createEmailForward/created.http
+++ b/fixtures/v2/api/createEmailForward/created.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 04 Feb 2016 14:26:51 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/createTemplate/created.http
+++ b/fixtures/v2/api/createTemplate/created.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 24 Mar 2016 11:09:16 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/createTemplateRecord/created.http
+++ b/fixtures/v2/api/createTemplateRecord/created.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Tue, 03 May 2016 07:51:33 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/createWebhook/created.http
+++ b/fixtures/v2/api/createWebhook/created.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Mon, 15 Feb 2016 17:04:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/createZoneRecord/created-apex.http
+++ b/fixtures/v2/api/createZoneRecord/created-apex.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 07 Jan 2016 17:45:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/createZoneRecord/created.http
+++ b/fixtures/v2/api/createZoneRecord/created.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 07 Jan 2016 17:45:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/deleteContact/error-contact-in-use.http
+++ b/fixtures/v2/api/deleteContact/error-contact-in-use.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Wed, 11 Apr 2018 10:50:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/fixtures/v2/api/disableDnssec/not-enabled.http
+++ b/fixtures/v2/api/disableDnssec/not-enabled.http
@@ -2,7 +2,7 @@ HTTP/1.1 428 Precondition Required
 Server: nginx
 Date: Fri, 03 Mar 2017 10:00:36 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/fixtures/v2/api/disableWhoisPrivacy/success.http
+++ b/fixtures/v2/api/disableWhoisPrivacy/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 13 Feb 2016 14:36:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/downloadCertificate/success.http
+++ b/fixtures/v2/api/downloadCertificate/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 11 Jun 2016 18:53:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/fixtures/v2/api/enableDnssec/success.http
+++ b/fixtures/v2/api/enableDnssec/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 03 Mar 2017 13:49:58 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/enableVanityNameServers/success.http
+++ b/fixtures/v2/api/enableVanityNameServers/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 14 Jul 2016 13:22:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/enableWhoisPrivacy/created.http
+++ b/fixtures/v2/api/enableWhoisPrivacy/created.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Sat, 13 Feb 2016 14:34:52 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/enableWhoisPrivacy/success.http
+++ b/fixtures/v2/api/enableWhoisPrivacy/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 13 Feb 2016 14:36:49 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/getCertificate/success.http
+++ b/fixtures/v2/api/getCertificate/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 08 Jul 2016 15:38:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/fixtures/v2/api/getCertificatePrivateKey/success.http
+++ b/fixtures/v2/api/getCertificatePrivateKey/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 11 Jun 2016 18:50:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/fixtures/v2/api/getContact/success.http
+++ b/fixtures/v2/api/getContact/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 19 Jan 2016 20:57:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/getDelegationSignerRecord/success.http
+++ b/fixtures/v2/api/getDelegationSignerRecord/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 03 Mar 2017 13:53:06 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/fixtures/v2/api/getDnssec/success.http
+++ b/fixtures/v2/api/getDnssec/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 03 Mar 2017 09:58:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/getDomain/success.http
+++ b/fixtures/v2/api/getDomain/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 21:54:55 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3993

--- a/fixtures/v2/api/getDomainDelegation/success-empty.http
+++ b/fixtures/v2/api/getDomainDelegation/success-empty.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:13:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/getDomainDelegation/success.http
+++ b/fixtures/v2/api/getDomainDelegation/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:17:18 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/getDomainPremiumPrice/failure.http
+++ b/fixtures/v2/api/getDomainPremiumPrice/failure.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Tue, 22 Nov 2016 10:48:27 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Cache-Control: no-cache
 X-Request-Id: 1304138f-0fc7-4845-b9ed-e3803409cb5a

--- a/fixtures/v2/api/getDomainPremiumPrice/success.http
+++ b/fixtures/v2/api/getDomainPremiumPrice/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 22 Nov 2016 10:46:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/getDomainTransfer/success.http
+++ b/fixtures/v2/api/getDomainTransfer/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 18 May 2020 17:03:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/fixtures/v2/api/getEmailForward/success.http
+++ b/fixtures/v2/api/getEmailForward/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 04 Feb 2016 14:42:46 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/getService/success.http
+++ b/fixtures/v2/api/getService/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 15 Apr 2016 14:50:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/getTemplate/success.http
+++ b/fixtures/v2/api/getTemplate/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 22 Mar 2016 11:14:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/getTemplateRecord/success.http
+++ b/fixtures/v2/api/getTemplateRecord/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 03 May 2016 08:04:20 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/getTld/success.http
+++ b/fixtures/v2/api/getTld/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 23 Sep 2016 09:06:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/fixtures/v2/api/getTldExtendedAttributes/success-attributes.http
+++ b/fixtures/v2/api/getTldExtendedAttributes/success-attributes.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sun, 28 Feb 2016 13:19:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/getTldExtendedAttributes/success-noattributes.http
+++ b/fixtures/v2/api/getTldExtendedAttributes/success-noattributes.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sun, 28 Feb 2016 13:19:18 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/getTldExtendedAttributes/success.http
+++ b/fixtures/v2/api/getTldExtendedAttributes/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sun, 28 Feb 2016 13:19:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/getWebhook/success.http
+++ b/fixtures/v2/api/getWebhook/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 15 Feb 2016 17:06:09 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/getWhoisPrivacy/success.http
+++ b/fixtures/v2/api/getWhoisPrivacy/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 13 Feb 2016 14:35:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/getZone/success.http
+++ b/fixtures/v2/api/getZone/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 22 Jan 2016 16:54:14 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/getZoneFile/success.http
+++ b/fixtures/v2/api/getZoneFile/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 20 Jul 2016 09:04:24 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/getZoneRecord/success.http
+++ b/fixtures/v2/api/getZoneRecord/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 05 Oct 2016 09:53:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2394

--- a/fixtures/v2/api/initiatePush/success.http
+++ b/fixtures/v2/api/initiatePush/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 11 Aug 2016 10:16:03 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395

--- a/fixtures/v2/api/issueLetsencryptCertificate/success.http
+++ b/fixtures/v2/api/issueLetsencryptCertificate/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 202 Accepted
 Server: nginx
 Date: Wed, 18 Oct 2017 15:42:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/issueRenewalLetsencryptCertificate/success.http
+++ b/fixtures/v2/api/issueRenewalLetsencryptCertificate/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 202 Accepted
 Server: nginx
 Date: Thu, 19 Oct 2017 08:22:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/listAccounts/success-account.http
+++ b/fixtures/v2/api/listAccounts/success-account.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:02:58 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2391

--- a/fixtures/v2/api/listAccounts/success-user.http
+++ b/fixtures/v2/api/listAccounts/success-user.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:05:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2390

--- a/fixtures/v2/api/listCertificates/success.http
+++ b/fixtures/v2/api/listCertificates/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 08 Jul 2016 15:38:52 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2394

--- a/fixtures/v2/api/listCollaborators/success.http
+++ b/fixtures/v2/api/listCollaborators/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 07 Oct 2016 08:58:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/fixtures/v2/api/listContacts/success.http
+++ b/fixtures/v2/api/listContacts/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 19 Jan 2016 18:35:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/listDelegationSignerRecords/success.http
+++ b/fixtures/v2/api/listDelegationSignerRecords/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 03 Mar 2017 13:50:42 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/fixtures/v2/api/listDomains/success.http
+++ b/fixtures/v2/api/listDomains/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/fixtures/v2/api/listEmailForwards/success.http
+++ b/fixtures/v2/api/listEmailForwards/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 04 Feb 2016 14:07:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/listPushes/success.http
+++ b/fixtures/v2/api/listPushes/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 11 Aug 2016 10:19:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2393

--- a/fixtures/v2/api/listServices/success.http
+++ b/fixtures/v2/api/listServices/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 10 Dec 2016 22:37:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/listTemplateRecords/success.http
+++ b/fixtures/v2/api/listTemplateRecords/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 03 May 2016 08:07:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/listTemplates/success.http
+++ b/fixtures/v2/api/listTemplates/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 22 Mar 2016 11:11:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/listTlds/success.http
+++ b/fixtures/v2/api/listTlds/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 23 Sep 2016 08:22:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/fixtures/v2/api/listWebhooks/success.http
+++ b/fixtures/v2/api/listWebhooks/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 15 Feb 2016 17:06:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/listZoneRecords/success.http
+++ b/fixtures/v2/api/listZoneRecords/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 05 Oct 2016 09:27:02 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/fixtures/v2/api/listZones/success.http
+++ b/fixtures/v2/api/listZones/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 22 Jan 2016 16:54:24 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/method-not-allowed.http
+++ b/fixtures/v2/api/method-not-allowed.http
@@ -1,7 +1,7 @@
 HTTP/1.1 405 Method Not Allowed
 Server: nginx
 Date: Fri, 15 Apr 2016 14:15:04 GMT
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 405 Method Not Allowed
 Allow: DELETE, GET, HEAD, PATCH, POST

--- a/fixtures/v2/api/notfound-certificate.http
+++ b/fixtures/v2/api/notfound-certificate.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Tue, 19 Jul 2016 08:56:34 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Cache-Control: no-cache
 X-Request-Id: 9a51fa7e-cc9b-498b-bf8d-ee3b2819c0c6

--- a/fixtures/v2/api/notfound-collaborator.http
+++ b/fixtures/v2/api/notfound-collaborator.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Mon, 21 Nov 2016 09:32:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Cache-Control: no-cache
 X-Request-Id: 3e76b10b-412c-42ef-87d1-f8ff327df997

--- a/fixtures/v2/api/notfound-contact.http
+++ b/fixtures/v2/api/notfound-contact.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Tue, 19 Jan 2016 21:04:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/fixtures/v2/api/notfound-delegationSignerRecord.http
+++ b/fixtures/v2/api/notfound-delegationSignerRecord.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 04 Feb 2016 14:44:56 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/fixtures/v2/api/notfound-domain.http
+++ b/fixtures/v2/api/notfound-domain.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Wed, 16 Dec 2015 22:07:20 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Strict-Transport-Security: max-age=31536000
 Cache-Control: no-cache

--- a/fixtures/v2/api/notfound-domainpush.http
+++ b/fixtures/v2/api/notfound-domainpush.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 04 Feb 2016 14:44:56 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/fixtures/v2/api/notfound-emailforward.http
+++ b/fixtures/v2/api/notfound-emailforward.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 04 Feb 2016 14:44:56 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/fixtures/v2/api/notfound-record.http
+++ b/fixtures/v2/api/notfound-record.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Fri, 22 Jan 2016 16:46:07 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/fixtures/v2/api/notfound-template.http
+++ b/fixtures/v2/api/notfound-template.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Wed, 04 May 2016 09:35:45 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/fixtures/v2/api/notfound-webhook.http
+++ b/fixtures/v2/api/notfound-webhook.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 03 Mar 2016 11:55:29 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/fixtures/v2/api/notfound-whoisprivacy.http
+++ b/fixtures/v2/api/notfound-whoisprivacy.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Sat, 13 Feb 2016 14:34:32 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/fixtures/v2/api/notfound-zone.http
+++ b/fixtures/v2/api/notfound-zone.http
@@ -2,7 +2,7 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Fri, 22 Jan 2016 16:46:02 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/fixtures/v2/api/oauthAccessToken/error-invalid-request.http
+++ b/fixtures/v2/api/oauthAccessToken/error-invalid-request.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Mon, 08 Feb 2016 21:24:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 30
 X-RateLimit-Remaining: 29

--- a/fixtures/v2/api/oauthAccessToken/success.http
+++ b/fixtures/v2/api/oauthAccessToken/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 08 Feb 2016 21:24:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 30

--- a/fixtures/v2/api/pages-1of3.http
+++ b/fixtures/v2/api/pages-1of3.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/fixtures/v2/api/pages-2of3.http
+++ b/fixtures/v2/api/pages-2of3.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/fixtures/v2/api/pages-3of3.http
+++ b/fixtures/v2/api/pages-3of3.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/fixtures/v2/api/purchaseLetsencryptCertificate/success.http
+++ b/fixtures/v2/api/purchaseLetsencryptCertificate/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Wed, 18 Oct 2017 15:40:32 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/purchaseRenewalLetsencryptCertificate/success.http
+++ b/fixtures/v2/api/purchaseRenewalLetsencryptCertificate/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 19 Oct 2017 08:18:53 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/registerDomain/success.http
+++ b/fixtures/v2/api/registerDomain/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:35:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/fixtures/v2/api/renewDomain/error-tooearly.http
+++ b/fixtures/v2/api/renewDomain/error-tooearly.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Mon, 15 Feb 2016 15:06:35 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 400 Bad Request
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/renewDomain/success.http
+++ b/fixtures/v2/api/renewDomain/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:46:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2394

--- a/fixtures/v2/api/renewWhoisPrivacy/success.http
+++ b/fixtures/v2/api/renewWhoisPrivacy/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 10 Jan 2019 12:12:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/fixtures/v2/api/renewWhoisPrivacy/whois-privacy-duplicated-order.http
+++ b/fixtures/v2/api/renewWhoisPrivacy/whois-privacy-duplicated-order.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Thu, 10 Jan 2019 12:13:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/fixtures/v2/api/renewWhoisPrivacy/whois-privacy-not-found.http
+++ b/fixtures/v2/api/renewWhoisPrivacy/whois-privacy-not-found.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Thu, 10 Jan 2019 12:11:39 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/fixtures/v2/api/response.http
+++ b/fixtures/v2/api/response.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991

--- a/fixtures/v2/api/transferDomain/error-indnsimple.http
+++ b/fixtures/v2/api/transferDomain/error-indnsimple.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Sun, 21 Feb 2016 13:11:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 400 Bad Request
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/transferDomain/error-missing-authcode.http
+++ b/fixtures/v2/api/transferDomain/error-missing-authcode.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Sun, 21 Feb 2016 13:11:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 400 Bad Request
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/transferDomain/success.http
+++ b/fixtures/v2/api/transferDomain/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:43:43 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395

--- a/fixtures/v2/api/updateContact/success.http
+++ b/fixtures/v2/api/updateContact/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 19 Jan 2016 21:28:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/fixtures/v2/api/updateTemplate/success.http
+++ b/fixtures/v2/api/updateTemplate/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:04:55 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/fixtures/v2/api/updateZoneRecord/success.http
+++ b/fixtures/v2/api/updateZoneRecord/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 05 Oct 2016 09:59:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2393

--- a/fixtures/v2/api/validation-error.http
+++ b/fixtures/v2/api/validation-error.http
@@ -2,7 +2,7 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Wed, 23 Nov 2016 08:12:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/fixtures/v2/api/whoami/success-account.http
+++ b/fixtures/v2/api/whoami/success-account.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991

--- a/fixtures/v2/api/whoami/success-user.http
+++ b/fixtures/v2/api/whoami/success-user.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991

--- a/fixtures/v2/api/whoami/success.http
+++ b/fixtures/v2/api/whoami/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991


### PR DESCRIPTION
Fixes #247 

This PR replaces the `Transfer-Encoding` header's value in all API fixtures from `chunked` to `identity` to make them replayable without further modification.