### PR TITLE
Remove required from Fax attribute

### DIFF
--- a/content/v2/contacts.markdown
+++ b/content/v2/contacts.markdown
@@ -101,7 +101,7 @@ Name | Type | Description
 `country`           | `string` | **Required**.
 `email`             | `string` | **Required**.
 `phone`             | `string` | **Required**.
-`fax`               | `string` | **Required**.
+`fax`               | `string` |
 
 ##### Example
 


### PR DESCRIPTION
Working on the contacts API, I noticed that the docs are showing that
the fax is required but it is not.

This commit remove the required flag from it.