### PR TITLE
Remove premium price from fixtures

### DIFF
--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -259,12 +259,12 @@ Name | Type | Description
 
 ### Example
 
-Get the domain transfer with ID `358` in the account `1010`:
+Get the domain transfer with ID `361` in the account `1010`:
 
 ~~~
 curl  -H 'Authorization: Bearer <token>' \
       -H 'Accept: application/json' \
-      https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/358
+      https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/361
 ~~~
 
 ### Response
@@ -294,13 +294,13 @@ Name | Type | Description
 
 ### Example
 
-Cancel the in progress domain transfer with ID `358` in the account `1010`:
+Cancel the in progress domain transfer with ID `361` in the account `1010`:
 
 ~~~
 curl  -H 'Authorization: Bearer <token>' \
       -H 'Accept: application/json' \
       -X DELETE \
-      https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/358
+      https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/361
 ~~~
 
 ### Response

--- a/fixtures/v2/api/cancelDomainTransfer/success.http
+++ b/fixtures/v2/api/cancelDomainTransfer/success.http
@@ -1,19 +1,19 @@
 HTTP/1.1 202 Accepted
 Server: nginx
-Date: Mon, 18 May 2020 16:55:35 GMT
+Date: Fri, 05 Jun 2020 18:09:42 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2398
-X-RateLimit-Reset: 1589824450
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1591384034
 Cache-Control: no-cache
-X-Request-Id: c9ecfbd2-3db4-4550-a6d6-8dd9f5b68a06
-X-Runtime: 0.905412
+X-Request-Id: 3cf6dcfa-0bb5-439e-863a-af2ef08bc830
+X-Runtime: 0.912731
 X-Frame-Options: DENY
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 X-Download-Options: noopen
 X-Permitted-Cross-Domain-Policies: none
 
-{"data":{"id":358,"domain_id":180716,"registrant_id":2459,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":null,"created_at":"2020-05-18T16:54:15Z","updated_at":"2020-05-18T16:54:22Z"}}
+{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"transferring","auto_renew":false,"whois_privacy":false,"status_description":null,"created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:08:04Z"}}

--- a/fixtures/v2/api/getDomainTransfer/success.http
+++ b/fixtures/v2/api/getDomainTransfer/success.http
@@ -1,16 +1,16 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Fri, 05 Jun 2020 18:09:11 GMT
+Date: Fri, 05 Jun 2020 18:23:53 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2395
+X-RateLimit-Remaining: 2392
 X-RateLimit-Reset: 1591384034
-ETag: W/"b65e21f810d2ee2a192d01a56d985b8f"
+ETag: W/"80c5827934c13b1ca87a587d96e7d1e8"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: ca7ebbcd-abc5-457d-80ef-c2537e26c90c
-X-Runtime: 0.134029
+X-Request-Id: 9f4959ee-06a9-488c-906e-27a570cafbbf
+X-Runtime: 0.078429
 X-Frame-Options: DENY
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
@@ -18,4 +18,4 @@ X-Download-Options: noopen
 X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"transferring","auto_renew":false,"whois_privacy":false,"status_description":null,"created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:08:04Z"}}
+{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"cancelled","auto_renew":false,"whois_privacy":false,"status_description":"Canceled by customer","created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:10:01Z"}}

--- a/fixtures/v2/api/getDomainTransfer/success.http
+++ b/fixtures/v2/api/getDomainTransfer/success.http
@@ -1,16 +1,16 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Mon, 18 May 2020 17:03:54 GMT
+Date: Fri, 05 Jun 2020 18:09:11 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2396
-X-RateLimit-Reset: 1589824450
-ETag: W/"9f81d47057f629dd921ccabff433ccac"
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1591384034
+ETag: W/"b65e21f810d2ee2a192d01a56d985b8f"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 7af4e96b-471d-4619-a0b6-b5d0d7261e75
-X-Runtime: 0.060273
+X-Request-Id: ca7ebbcd-abc5-457d-80ef-c2537e26c90c
+X-Runtime: 0.134029
 X-Frame-Options: DENY
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
@@ -18,4 +18,4 @@ X-Download-Options: noopen
 X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":358,"domain_id":180716,"registrant_id":2459,"state":"cancelled","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":"Canceled by customer","created_at":"2020-05-18T16:54:15Z","updated_at":"2020-05-18T17:00:02Z"}}
+{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"transferring","auto_renew":false,"whois_privacy":false,"status_description":null,"created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:08:04Z"}}


### PR DESCRIPTION
We dropped the premium_price attribute from Domain
Transfer/Registration/Renewal API response. This commit drops the
premium_price attribute from the Transfers fixtures that was relying on
it.