### PR TITLE
Fixes typo on zone records

### DIFF
--- a/content/v2/zones/records.markdown
+++ b/content/v2/zones/records.markdown
@@ -222,7 +222,7 @@ curl  -H 'Authorization: Bearer <token>' \
 
 ### Input
 
-The following fields are updateable. You can pass zero of any of them.
+The following fields are updateable. You can pass zero or any of them.
 
 Name | Type | Description
 -----|------|------------


### PR DESCRIPTION
Fixes typo on https://developer.dnsimple.com/v2/zones/records/#updateZoneRecord