### PR TITLE
Mark Email from/to as deprecated

### DIFF
--- a/content/v2/domains/email-forwards.markdown
+++ b/content/v2/domains/email-forwards.markdown
@@ -82,15 +82,15 @@ Create an email forward under the domain `example.com` in the account `1010`:
 
 Name | Type | Description
 -----|------|------------
-`from` | `string` | **Required**. The email address the emails are sent to.
-`to` | `string` | **Required**. The email address the email address the emails are forwarded to.
+`alias_name` | `string` | **Required**. The receiving email recipient, the name part only without the domain. The domain is automatically appended.
+`destination_email` | `string` | **Required**. The email recipient the messages are delivered to.
 
 ##### Example
 
 ~~~json
 {
-  "from": "jim@a-domain.com",
-  "to": "jim@another.com"
+  "alias_name": "john.doe",
+  "destination_email": "john@another.com"
 }
 ~~~
 

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2989,26 +2989,38 @@ components:
         updated_at: '2017-02-03T17:43:22.000Z'
     EmailForward:
       type: object
+      example:
+        id: 1
+        domain_id: 2
+        alias_email: john.doe@a-domain.com
+        destination_email: john@example.com
+        created_at: '2016-02-04T14:26:50Z'
+        updated_at: '2016-02-04T14:26:50Z'
       properties:
         id:
           type: integer
         domain_id:
           type: integer
+        alias_email:
+          type: string
+          format: email
+          description: The receiving email recipient.
+        destination_email:
+          type: string
+          format: email
+          description: The email recipient the messages are delivered to.
         from:
           type: string
+          deprecated: true
+          description: Deprecated in favor of alias_email.
         to:
           type: string
+          deprecated: true
+          description: Deprecated in favor of destination_email.
         created_at:
           $ref: '#/components/schemas/DateTime'
         updated_at:
           $ref: '#/components/schemas/DateTime'
-      example:
-        id: 1
-        domain_id: 2
-        from: john.doe@a-domain.com
-        to: john@example.com
-        created_at: '2016-02-04T14:26:50Z'
-        updated_at: '2016-02-04T14:26:50Z'
     EventAccountAddUser:
       type: object
       description: Payload for account.add_user event.
@@ -4557,10 +4569,13 @@ components:
           schema:
             type: object
             properties:
-              from:
+              alias_name:
                 type: string
-              to:
+                description: The receiving email recipient, the name part only without the domain. The domain is automatically appended.
+              destination_email:
                 type: string
+                format: email
+                description: The email recipient the messages are delivered to.
             example:
               from: john.doe
               to: john@example.com

--- a/fixtures/v2/api/createEmailForward/created.http
+++ b/fixtures/v2/api/createEmailForward/created.http
@@ -1,17 +1,22 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Thu, 04 Feb 2016 14:26:51 GMT
+Date: Mon, 25 Jan 2021 13:54:40 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
-Status: 201 Created
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3991
-X-RateLimit-Reset: 1454596042
-ETag: W/"10dd958c5a3a43eec0af1d8da655cab0"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4772
+X-RateLimit-Reset: 1611583415
+ETag: W/"80ad3ad1e115a8123193447fa003f68a"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: fca523a2-aad9-49e6-a828-a0e7711a8501
-X-Runtime: 1.711621
+X-Request-Id: 1086590f-0e65-4010-8636-031400a662bf
+X-Runtime: 0.880228
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":17706,"domain_id":228963,"from":"jim@a-domain.com","to":"jim@another.com","created_at":"2016-02-04T14:26:50Z","updated_at":"2016-02-04T14:26:50Z"}}
+{"data":{"id":41872,"domain_id":235146,"alias_email":"example@dnsimple.xyz","destination_email":"example@example.com","created_at":"2021-01-25T13:54:40Z","updated_at":"2021-01-25T13:54:40Z","from":"example@dnsimple.xyz","to":"example@example.com"}}

--- a/fixtures/v2/api/deleteEmailForward/success.http
+++ b/fixtures/v2/api/deleteEmailForward/success.http
@@ -1,13 +1,18 @@
 HTTP/1.1 204 No Content
 Server: nginx
-Date: Thu, 04 Feb 2016 17:14:52 GMT
+Date: Mon, 25 Jan 2021 13:56:43 GMT
 Connection: keep-alive
-Status: 204 No Content
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3999
-X-RateLimit-Reset: 1454609692
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4765
+X-RateLimit-Reset: 1611583416
 Cache-Control: no-cache
-X-Request-Id: 716d181c-495d-47ab-ab79-391a70e8abe1
-X-Runtime: 0.145208
+X-Request-Id: bfaceb73-4fd3-4490-8528-472ec1df3526
+X-Runtime: 0.506670
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 

--- a/fixtures/v2/api/getEmailForward/success.http
+++ b/fixtures/v2/api/getEmailForward/success.http
@@ -1,17 +1,22 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Thu, 04 Feb 2016 14:42:46 GMT
+Date: Mon, 25 Jan 2021 13:56:24 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
-Status: 200 OK
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3999
-X-RateLimit-Reset: 1454600566
-ETag: W/"10dd958c5a3a43eec0af1d8da655cab0"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4766
+X-RateLimit-Reset: 1611583416
+ETag: W/"80ad3ad1e115a8123193447fa003f68a"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: fde15363-9332-4b91-bd8f-00b144eb8081
-X-Runtime: 0.022117
+X-Request-Id: 8f3a9517-f623-4d14-be2b-3f332a4d7873
+X-Runtime: 0.010653
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":17706,"domain_id":228963,"from":"jim@a-domain.com","to":"jim@another.com","created_at":"2016-02-04T14:26:50Z","updated_at":"2016-02-04T14:26:50Z"}}
+{"data":{"id":41872,"domain_id":235146,"alias_email":"example@dnsimple.xyz","destination_email":"example@example.com","created_at":"2021-01-25T13:54:40Z","updated_at":"2021-01-25T13:54:40Z","from":"example@dnsimple.xyz","to":"example@example.com"}}


### PR DESCRIPTION
These fields has been replaced by `alias_email`, `destination_email` in response and `alias_name`, `destination_email` in request payload to better reflect the nature of the value and avoid ambiguity with same field holding different formats.

The API will continue to support and return both for now.

- [x] Update OpenAPI definition
- [x] Update response fixtures
- [x] Update clients https://github.com/dnsimple/dnsimple-developer/issues/315