### PR TITLE
Create ifstated.conf

### DIFF
--- a/content/ddns/ifstated.conf
+++ b/content/ddns/ifstated.conf
@@ -1,0 +1,71 @@
+# Tested on OpenBSD 6.8
+
+# Based on https://github.com/vedetta-com/vedetta/blob/master/src/etc/ifstated.conf
+
+# The "Dynamic DNS Shell Script" from https://developer.dnsimple.com/ddns/ is
+# required. The shebang needs to be changed from "#!/bin/bash" to "#!/bin/sh"
+
+# Lines 13, 16, 17, 32, 48 need to be tweaked per environment
+
+init-state auto
+
+# Monitor interface em0
+egress_up  = "em0.link.up"
+
+# Ping a well-known IPv4 address to check for connectivity
+inet = '( "ping -q -c 1 -w 4 1.1.1.1 > /dev/null" every 10 || \
+          "ping -q -c 1 -w 4 8.8.8.8 > /dev/null" every 13 )'
+
+state auto {
+    if (! $egress_up) {
+        run "logger -t ifstated '(auto) egress down'"
+        set-state ifdown
+    }
+    if ($egress_up) {
+        run "logger -t ifstated '(auto) egress up'"
+        set-state ifup
+    }
+}
+
+state ifdown {
+    init {
+        run "sh /etc/netstart em0 && \
+            logger -t ifstated '(ifdown) egress reset'"
+    }
+    if ($egress_up) {
+        run "logger -t ifstated '(ifdown) egress up'"
+        set-state ifup
+    }
+}
+
+state ifup {
+    init {
+        run "logger -t ifstated '(ifup) entered ifup state'"
+    }
+    if ($inet) {
+        run "logger -t ifstated '(ifup) IPv4 up'"
+        run "logger -t ifstated '(internet) Starting ddns update'"
+        run "sh /usr/local/bin/ddns.sh"
+        run "logger -t ifstated '(internet) Finished ddns update'"
+        run "ifconfig egress | grep inet | \
+             mail -s '(ifup) IPv4 up' root"
+        set-state internet
+    }
+    if (! $inet && "sleep 10" every 10) {
+        run "logger -t ifstated '(ifup) IPv4 down'"
+        set-state ifdown
+    }
+}
+
+state internet {
+    init {
+        run "logger -t ifstated '(ifup) entered internet state'"
+    }
+    if ($inet) {
+        run "logger -t ifstated '(internet) IPv4 up'"
+    }
+    if (! $inet) {
+        run "logger -t ifstated '(internet) IPv4 down'"
+        set-state auto
+    }
+}


### PR DESCRIPTION
Hi!

The main purpose of this ifstated.conf is to keep DNSimple API queries to a minimum, instead of calling ddns.sh every 5min via cron. The ddns.sh is still needed as quickly stated on the comments. The way it's implemented now is that ifstated runs ddns.sh only if it detects that the ping tests have failed.

It's a dirty hack, I'm sure more functionality can be added if needed. For example detecting quick dynamic DNS changes enforced by the ISP. Maybe using dig on special domains and comparing the IP against ifconfig outputs.

Let me know if further changes are needed! Thanks!