### PR TITLE
Remove the required flag for Template's description

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -4645,12 +4645,15 @@ components:
           schema:
             type: object
             properties:
-              name:
-                type: string
               sid:
+                type: string
+              name:
                 type: string
               description:
                 type: string
+            required:
+              - sid
+              - name
             example:
               name: Alpha
               sid: alpha

--- a/content/v2/templates.markdown
+++ b/content/v2/templates.markdown
@@ -82,7 +82,7 @@ Name | Type | Description
 -----|------|------------
 `name` | `string` | **Required**.
 `sid` | `string` | **Required**.
-`description` | `string` | **Required**.
+`description` | `string` |
 
 ##### Example
 


### PR DESCRIPTION
This field is not required. This commit removes the required flag from
it.