### PR TITLE
Expand documentation about this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,22 @@
+# Contributing
+
+## Setup
+
+1. Clone this repository
+1. Run `asdf install`
+1. Run `bundle install`
+1. Start your local instance with `rake run`
+
+The site will be visible at [localhost:3000](http://localhost:3000).
+
+## Development
+
+Use `rake run` to start the site. The server will automatically re-compiles changed files.
+
+## Deployment
+
+The `main` branch is deployed automatically via Netlify.
+
 ## Creating new fixtures
 
 - Use the sandbox API. Avoid using the production API as much as possible.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 # DNSimple API Documentation
 
-This is the [DNSimple API documentation](https://developer.dnsimple.com/) built with [nanoc](https://nanoc.ws/).
+This is the [DNSimple API documentation](https://developer.dnsimple.com/).
 
-## Setup
+## Usage
 
-1. Clone this repository
-1. Run `asdf install`
-1. Run `bundle install`
-1. Start your local instance with `rake run`
+This website is built with [nanoc](https://nanoc.ws/). If you want to learn how to run the site locally, or how to contribute, please visit the [CONTRIBUTING](CONTRIBUTING.md) file.
 
-The site will be visible at [localhost:3000](http://localhost:3000).
+## Structure
 
+These are the most important folders and files to keep in mind while working on this repo:
 
-## Development
+- `content`: this folder contains the markdown files that generate the site
+- `content/v2/openapi.yml`: the API definition described using the OpenAPI specification (see below)
+- `examples`: this folder contains the API response fixtures generated from real API calls you can use to test your integrations
 
-Use `rake run` to start the site. The server will automatically re-compiles changed files.
+## OpenAPI definition
 
+The API behavior is described using the [OpenAPI](https://www.openapis.org/) specification. The definition file is located at [content/v2/openapi.yml](content/v2/openapi.yml).
 
-## Deployment
+The OpenAPI description is the main source of truth, and must be kept up to date with the other changes in the site. At the time being, the site and the OpenAPI must be kept in sync manually. That means any change in the markdown documentation files needs to be reflected in the OpenAPI file.
 
-Each commit to main is deployed automatically via Netlify.
-
-
+The markdown documentation is a subset of the OpenAPI description. There may be information that - for the sake of brevity - are omitted in the markdown files, and sometimes delegated to the OpenAPI description.


### PR DESCRIPTION
As I was commenting in https://github.com/dnsimple/dnsimple-developer/pull/323#issuecomment-790001814, I realized we don't have any documentation about how this repo is structured and what are the most important constraints/files to work on.

I expanded the docs a bit. The current README is mostly all moved to CONTRIBUTING as it's very engineering oriented (for people who wants to run the site locally or contribute).
