### PR TITLE
Mark getDomainPrices as Public preview

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -902,7 +902,7 @@ paths:
       summary: Get domain premium price
   '/{account}/registrar/domains/{domain}/prices':
     get:
-      description: Retrieves the domain price for registration, renewal, and transfer.
+      description: Retrieve domain prices.
       summary: Get prices for a domain
       parameters:
         - $ref: '#/components/parameters/Account'

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -105,7 +105,7 @@ Responds with HTTP 400, if the domain isn't premium.
 <%= pretty_print_fixture("/api/getDomainPremiumPrice/failure.http") %>
 ~~~
 
-## Retrieve domain price for registration, renewal, and transfer {#getDomainPrices}
+## Retrieve domain prices {#getDomainPrices}
 
 Get a domain's price for registration, renewal, and transfer.
 

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -109,9 +109,7 @@ Responds with HTTP 400, if the domain isn't premium.
 
 Get a domain's price for registration, renewal, and transfer.
 
-<info>
-The described API endpoint is in Public Beta, and can change without prior notice.
-</info>
+<%= render "v2-preview" %>
 
 ~~~
 GET /:account/registrar/domains/:domain/prices

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -141,10 +141,6 @@ Responds with HTTP 200 on success, returns the domain pricing for registration, 
 <%= pretty_print_fixture("/api/getDomainPrices/success.http") %>
 ~~~
 
-<note>
-If the domain is premium (`premium: true`), please [check the premium price](#getDomainPremiumPrice) before to try to [register](#register), [renew](#renew), [transfer](#transfer).
-</note>
-
 Responds with HTTP 400, if the domain TLD is not supported.
 
 ~~~json


### PR DESCRIPTION
This commit marks our getDomainPrices endpoint as public preview.

![image](https://user-images.githubusercontent.com/771411/114603792-86fd1280-9c6e-11eb-88c1-52d5e9e47c8b.png)
