### PR TITLE
Add link to the Secondary DNS API article in the sidebar

### DIFF
--- a/layouts/sidebar.html
+++ b/layouts/sidebar.html
@@ -32,6 +32,7 @@
   <li><ul class="nav-list">
     <li><a href="/v2/zones/records/">Records</a></li>
   </ul></li>
+  <li><a href="/v2/secondary-dns/">Secondary DNS</a></li>
   <li><a href="/v2/contacts/">Contacts</a></li>
   <li><a href="/v2/services/">Services</a></li>
   <li><ul class="nav-list">


### PR DESCRIPTION
This PR links the article for Secondary DNS API in the sidebar, just below the `Zones` link.

![image](https://user-images.githubusercontent.com/205913/115208869-58af8500-a0fd-11eb-9869-5f3faeea8e81.png)
