### PR TITLE
deprecate getDomainPremiumPrice endpoint

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -876,7 +876,10 @@ paths:
       summary: Check domain
   '/{account}/registrar/domains/{domain}/premium_price':
     get:
+      deprecated: true
       description: |-
+        Deprecated in favor of getDomainPrices.
+
         Retrieves the premium price for a premium domain.
 
         Please note that a premium price can be different for registration, renewal, transfer. By default this endpoint returns the premium price for registration. If you need to check a different price, you should specify it with the action param.

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -49,6 +49,10 @@ If the domain is premium (`premium: true`), please [check the premium price](#ge
 
 ## Check domain premium price {#getDomainPremiumPrice}
 
+<note>
+Deprecated in favor of [getDomainPrices](#getDomainPrices).
+</note>
+
 Get the premium price for a domain.
 
 ~~~

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -44,7 +44,7 @@ Responds with HTTP 200 on success, returns the domain availability information.
 ~~~
 
 <note>
-If the domain is premium (`premium: true`), please [check the premium price](#getDomainPremiumPrice) before to try to [register](#register), [renew](#renew), [transfer](#transfer).
+If the domain is premium (`premium: true`), please [check the premium price](#getDomainPrices) before to try to [register](#register), [renew](#renew), [transfer](#transfer).
 </note>
 
 ## Check domain premium price {#getDomainPremiumPrice}
@@ -193,7 +193,7 @@ The `registrant_id` can be fetched via the [contacts endpoint](/v2/contacts) and
 </info>
 
 <info>
-The `premium_price` can be fetched via the [premium price endpoint](#getDomainPremiumPrice).
+The `premium_price` can be fetched via the [prices endpoint](#getDomainPrices).
 </info>
 
 ##### Example


### PR DESCRIPTION
With the public beta release of we deprecate getDomainPremiumPrice.

This PR updates the docs to reflect this.