### PR TITLE
Update documentation with endpoint rate limits

### DIFF
--- a/content/v2.markdown
+++ b/content/v2.markdown
@@ -281,6 +281,10 @@ There is a limit to the number of requests that you can perform per hour.
 - For **authenticated requests** you can make **up to 2400 requests per hour**.
 - For **unauthenticated requests**, you can make **up to 30 requests per hour**.
 
+<note>
+  Individual endpoints can also have a separate rate limit. Such limits are made known in the endpoint's documentation.
+</note>
+
 You can see your current rate limit status by checking the HTTP headers of any API request:
 
 ~~~

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -17,6 +17,10 @@ Checks a domain name for availability.
 GET /:account/registrar/domains/:domain/check
 ~~~
 
+<note>
+  For this endpoint you can make **up to 60 requests per hour**. If you need to increase the limits [please reach out to us](https://dnsimple.com/contact).
+</note>
+
 ### Parameters
 
 Name | Type | Description


### PR DESCRIPTION
Add missing documentation of checkDomain endpoint's rate limit, and make it known in the general section that such limits can apply.