### PR TITLE
Bumps ruby to 3.0.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 # Update also: .travis.yml
-ruby 2.7.5
+ruby 3.0.4
 nodejs 16.13.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 # Update also: .travis.yml
 ruby 3.0.4
-nodejs 16.13.0
+nodejs 16.14.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.7.5
+  - 3.0.4
 
 cache:
   bundler: true

--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,5 @@ end
 group :nanoc do
   gem 'guard-nanoc'
 end
+
+gem "puma", "~> 5.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       nanoc-cli (~> 4.11, >= 4.11.15)
       nanoc-core (~> 4.11, >= 4.11.15)
     nenv (0.3.0)
+    nio4r (2.5.8)
     nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -98,6 +99,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
+    puma (5.6.4)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
     rake (13.0.6)
@@ -136,6 +139,7 @@ DEPENDENCIES
   minitest-reporters
   nanoc (~> 4.12)
   nokogiri
+  puma (~> 5.6)
   rake
   rouge
   sass


### PR DESCRIPTION
I've added puma because Ruby 3.0 and later does not come with WEBrick by default so we can start the app locally.