### PR TITLE
Update certificate documentation & OpenAPI specs

### DIFF
--- a/content/v2/certificates.markdown
+++ b/content/v2/certificates.markdown
@@ -220,14 +220,9 @@ Purchase a Let's Encrypt certificate for `bingo.pizza` in the account `1010`:
 
 Name | Type | Description
 -----|------|------------
-`contact_id` | `integer` | **Required**. The ID of an existing contact in your account.
 `auto_renew` | `bool` | Set to true to enable the auto-renewal of the certificate. Default: `false`.
 `name` | `string` | The certificate name. Default: `"www"`.
 `alternate_names` | `array<string>` | The certificate _alternate names_. Default: `[]`. Example: `["docs.example.com", "status.example.com"]`
-
-<info>
-The `contact_id` can be fetched via the [contacts endpoint](/v2/contacts).
-</info>
 
 ### Response
 

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2730,6 +2730,7 @@ components:
           type: integer
         contact_id:
           type: integer
+          deprecated: true
         name:
           type: string
         common_name:


### PR DESCRIPTION
We are no longer requiring a `contact_id` to be provided to purchase a LetsEncrypt certificate.