### PR TITLE
Improve documentation about error responses

### DIFF
--- a/content/v2.markdown
+++ b/content/v2.markdown
@@ -104,11 +104,11 @@ DNSimple uses conventional HTTP response codes to indicate success or failure of
 
 ### Error
 
-- `400 Bad Request` - A required parameter or the request is invalid.
-- `401 Unauthorized` - The authentication credentials are invalid.
+- `400 Bad Request` - The request is invalid or there is an issue with the request payload. See [Errors](#errors).
+- `401 Unauthorized` - The authentication credentials are invalid. See [Authentication](#authentication).
 - `402 Payment Required` - Your account is not subscribed or not in good standing.
-- `404 Not Found` - The requested resource doesn't exist.
-- `429 Too Many Requests` - You exceeded the allowed number of requests per hour and your request has temporarily been throttled.
+- `404 Not Found` - The requested resource doesn't exist or the authenticated account doesn't have permissions to access the resource.
+- `429 Too Many Requests` - You exceeded the allowed number of requests per hour and your request has temporarily been throttled. See [Rate limitting](#rate-limiting).
 
 ### Kaboom!
 

--- a/content/v2.markdown
+++ b/content/v2.markdown
@@ -134,10 +134,71 @@ The `data` element will contain either a single JSON object or a list of JSON ob
 
 ## Errors
 
-Error responses will be returned as a JSON object with at least a `message` key. For example, failure to authenticate would result in a 401 response with a body like this:
+All responses with an 4xx and 5xx response code will have a JSON object as body, with at least a `message` key. Depending on the error type, the response may include an `errors` key with more details about why the respones was unsuccessful and what .
+
+Here are some examples of response bodies for response codes:
+
+### 400 - Bad Request
+~~~json
+{
+  "message": "The contact cannot be deleted: contact is in use",
+  "errors": {}
+}
+~~~
 
 ~~~json
-{"message":"Authentication failed"}
+{
+  "message": "We were unable to authorize the payment for this purchase on your card. Payment gateway returned error code: card_declined (generic_decline).",
+  "errors": {}
+}
+~~~
+
+~~~json
+{
+  "message": "Validation failed",
+  "errors": {
+    "ttl": ["is not a number"],
+    "content": ["can't be blank"],
+    "record_type": ["unsupported"]
+  }
+}
+~~~
+
+~~~json
+{
+  "message": "Validation failed",
+  "errors": {
+    "address1": ["can't be blank"],
+    "city": ["can't be blank"],
+    "country": ["is the wrong length (should be 2 characters)","is not a valid country"],
+    "email": ["can't be blank","is an invalid email address"],
+    "first_name": ["can't be blank"],
+    "last_name": ["can't be blank"],
+    "postal_code": ["can't be blank"],
+    "state_province": ["can't be blank"],
+    "phone": ["is probably not a phone number"]
+  }
+}
+~~~
+
+### 401 - Unauthorized
+~~~json
+{"message": "Authentication failed"}
+~~~
+
+### 402 - Payment required
+~~~json
+{"message": "This action cannot be completed because you have purchase invoices that need to be paid for: 12345-1010. Please retry the payment following these instructions https://support.dnsimple.com/articles/account-invoice-history/#retrying."}
+~~~
+
+### 404 - Not found
+~~~json
+{"message": "Not Found"}
+~~~
+
+### 429 - Too Many Requests
+~~~json
+{"message": "quota exceeded"}
 ~~~
 
 

--- a/content/v2.markdown
+++ b/content/v2.markdown
@@ -143,6 +143,10 @@ Here are some examples of response bodies for response codes:
 Depending on the error, the response may include an `errors` key with more details about why the request was unsuccessful and what specific data is invalid.
 
 ~~~json
+{ "message": "TLD .PINEAPPLE is not supported" }
+~~~
+
+~~~json
 {
   "message": "The contact cannot be deleted: contact is in use",
   "errors": {}

--- a/content/v2.markdown
+++ b/content/v2.markdown
@@ -199,6 +199,32 @@ Depending on the error, the response may include an `errors` key with more detai
 {"message": "Not Found"}
 ~~~
 
+### 412 - Precondition Failed
+~~~json
+{"message": "Let's Encrypt feature is not enabled for the account email@example.com"}
+~~~
+
+~~~json
+{"message": "The certificate requires the custom-name feature that is not available on the current plan for the account email@example.com"}
+~~~
+
+~~~json
+{"message": "The certificate requires the SAN feature that is not available on the current plan for the account email@example.com"}
+~~~
+
+~~~json
+{"message": "The certificate requires the wildcard feature that is not available on the current plan for the account email@example.com"}
+~~~
+
+### 428 - Precondition Required
+~~~json
+{"message": "Certificate not issued"}
+~~~
+
+~~~json
+{"message": "Private key not present"}
+~~~
+
 ### 429 - Too Many Requests
 ~~~json
 {"message": "quota exceeded"}

--- a/content/v2.markdown
+++ b/content/v2.markdown
@@ -134,11 +134,14 @@ The `data` element will contain either a single JSON object or a list of JSON ob
 
 ## Errors
 
-All responses with an 4xx and 5xx response code will have a JSON object as body, with at least a `message` key. Depending on the error type, the response may include an `errors` key with more details about why the respones was unsuccessful and what .
+All responses with an 4xx and 5xx response code will have a JSON object as body, with at least a `message` key.
 
 Here are some examples of response bodies for response codes:
 
 ### 400 - Bad Request
+
+Depending on the error, the response may include an `errors` key with more details about why the request was unsuccessful and what specific data is invalid.
+
 ~~~json
 {
   "message": "The contact cannot be deleted: contact is in use",

--- a/content/v2.markdown
+++ b/content/v2.markdown
@@ -234,6 +234,10 @@ Depending on the error, the response may include an `errors` key with more detai
 {"message": "quota exceeded"}
 ~~~
 
+### 504 - Gateway Timeout
+~~~json
+{"message": "Could not query zone, connection timed out"}
+~~~
 
 ## Timestamps
 

--- a/content/v2/accounts.markdown
+++ b/content/v2/accounts.markdown
@@ -45,3 +45,7 @@ Responds with HTTP 200. Depending on how you are authenticated you will see all 
 ~~~json
 <%= pretty_print_fixture("/api/listAccounts/success-user.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/certificates.markdown
+++ b/content/v2/certificates.markdown
@@ -27,22 +27,6 @@ Name | Type | Description
 `:account` | `integer` | The account id
 `:domain` | `string`, `integer` | The domain name or id
 
-### Example
-
-List all certificates for the domain `dnsimple.us` in the account `1010`:
-
-    curl  -H 'Authorization: Bearer <token>' \
-          -H 'Accept: application/json' \
-          https://api.dnsimple.com/v2/1010/domains/dnsimple.us/certificates
-
-### Response
-
-Responds with HTTP 200.
-
-~~~json
-<%= pretty_print_fixture("/api/listCertificates/success.http") %>
-~~~
-
 ### Sorting
 
 For general information about sorting, please refer to the [main guide](/v2/#sorting).
@@ -54,6 +38,26 @@ Name | Description
 `expiration` | Sort by expiration date
 
 The default sorting policy is by descending `id`.
+
+### Example
+
+List all certificates for the domain `dnsimple.us` in the account `1010`:
+
+    curl  -H 'Authorization: Bearer <token>' \
+          -H 'Accept: application/json' \
+          https://api.dnsimple.com/v2/1010/domains/dnsimple.us/certificates
+
+### Response
+
+Responds with HTTP 200 on success.
+
+~~~json
+<%= pretty_print_fixture("/api/listCertificates/success.http") %>
+~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Retrieve a certificate {#getCertificate}
@@ -80,11 +84,15 @@ Get the certificate with the ID `101967` in the domain `bingo.pizza`, in the acc
 
 ### Response
 
-Responds with HTTP 200, renders the certificate.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/getCertificate/success.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Download a certificate {#downloadCertificate}
@@ -111,11 +119,17 @@ Download the certificate with the ID `1` in the domain `example.com`, in the acc
 
 ### Response
 
-Responds with HTTP 200, renders the certificates.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/downloadCertificate/success.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 428](/v2#precondition-required) if the certificate cannot be downloaded.
 
 
 ## Retrieve a certificate private key {#getCertificatePrivateKey}
@@ -147,6 +161,12 @@ Responds with HTTP 200, renders the certificate private key.
 ~~~json
 <%= pretty_print_fixture("/api/getCertificatePrivateKey/success.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 428](/v2#precondition-required) if the private key cannot be downloaded.
 
 
 ## Let's Encrypt: Order a certificate {#purchaseLetsencryptCertificate}
@@ -226,10 +246,19 @@ Name | Type | Description
 
 ### Response
 
+Responds with HTTP 201 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/purchaseLetsencryptCertificate/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the certificate cannot be ordered.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 412](/v2#precondition-failed) if the account cannot order this certificate type.
 
 ## Let's Encrypt: Issue a certificate {#issueLetsencryptCertificate}
 
@@ -258,6 +287,8 @@ Issue a Let's Encrypt certificate with ID `101967`, for `bingo.pizza` in the acc
 
 ### Response
 
+Responds with HTTP 202 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/issueLetsencryptCertificate/success.http") %>
 ~~~
@@ -266,6 +297,14 @@ Issue a Let's Encrypt certificate with ID `101967`, for `bingo.pizza` in the acc
 The certificate will be in state `requesting`, and it can't be [downloaded](#download) until issued by Let's Encrypt.
 You can **subscribe to a [webhook](/v2/webhooks)** to receive a notification when the certificate is issued.
 </tip>
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the certificate cannot be issued.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 412](/v2#precondition-failed) if the account cannot issue this certificate type.
 
 
 ## Let's Encrypt: Order a certificate renewal {#purchaseRenewalLetsencryptCertificate}
@@ -310,9 +349,19 @@ Name | Type | Description
 
 ### Response
 
+Responds with HTTP 201 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/purchaseRenewalLetsencryptCertificate/success.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the certificate renewal cannot be ordered.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 412](/v2#precondition-failed) if the account cannot renew this certificate type.
 
 
 ## Let's Encrypt: Issue a certificate renewal {#issueRenewalLetsencryptCertificate}
@@ -347,6 +396,8 @@ Issue a Let's Encrypt certificate renewal with ID `65082`, for the certificate `
 
 ### Response
 
+Responds with HTTP 202 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/issueRenewalLetsencryptCertificate/success.http") %>
 ~~~
@@ -355,3 +406,11 @@ Issue a Let's Encrypt certificate renewal with ID `65082`, for the certificate `
 The certificate will be in state `requesting`, and it can't be [downloaded](#downloadCertificate) until issued by Let's Encrypt.
 You can subscribe to a [webhook](/v2/webhooks) to be notified once the certificate is issued.
 </tip>
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the certificate renewal cannot be issued.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 412](/v2#precondition-failed) if the account cannot issue this certificate type.

--- a/content/v2/contacts.markdown
+++ b/content/v2/contacts.markdown
@@ -28,6 +28,18 @@ Name | Type | Description
 -----|------|------------
 `:account` | `integer` | The account id
 
+### Sorting
+
+For general information about sorting, please refer to the [main guide](/v2/#sorting).
+
+Name | Description
+-----|------------
+`id` | Sort contacts by ID
+`label` | Sort contacts by label (alphabetical order)
+`email` | Sort contacts by email (alphabetical order)
+
+The default sorting policy is by ascending `id`.
+
 ### Example
 
 List all contacts in the account `1010`:
@@ -40,23 +52,15 @@ curl  -H 'Authorization: Bearer <token>' \
 
 ### Response
 
-Responds with HTTP 200.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/listContacts/success.http") %>
 ~~~
 
-### Sorting
+### Errors
 
-For general information about sorting, please refer to the [main guide](/v2/#sorting).
-
-Name | Description
------|------------
-`id` | Sort contacts by ID
-`label` | Sort contacts by label (alphabetical order)
-`email` | Sort contacts by email (alphabetical order)
-
-The default sorting policy is by ascending `id`.
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Create a contact {#createContact}
@@ -131,7 +135,11 @@ Responds with HTTP 201 on success.
 <%= pretty_print_fixture("/api/createContact/created.http") %>
 ~~~
 
-Responds with HTTP 400 if the validation fails.
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the contact cannot be created.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Retrieve a contact {#getContact}
@@ -159,10 +167,15 @@ curl  -H 'Authorization: Bearer <token>' \
 
 ### Response
 
+Responds with HTTP 200 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/getContact/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Update a contact {#updateContact}
 
@@ -202,8 +215,11 @@ Responds with HTTP 200 on success.
 <%= pretty_print_fixture("/api/updateContact/success.http") %>
 ~~~
 
-Responds with HTTP 400 if the validation fails.
+### Errors
 
+Responds with [HTTP 400](/v2#bad-request) if the contact cannot be updated.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Delete a contact {#deleteContact}
 
@@ -234,8 +250,12 @@ curl  -H 'Authorization: Bearer <token>' \
 
 Responds with HTTP 204 on success.
 
-Responds with HTTP 400 if the contact cannot be deleted because it's currently used by a domain or a certificate.
-
 ~~~json
 <%= pretty_print_fixture("/api/deleteContact/error-contact-in-use.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the contact cannot be deleted.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/domains.markdown
+++ b/content/v2/domains.markdown
@@ -73,6 +73,9 @@ Responds with HTTP 200.
 <%= pretty_print_fixture("/api/listDomains/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Create a domain {#createDomain}
 
@@ -123,9 +126,13 @@ Responds with HTTP 201 on success, renders the domain.
 <%= pretty_print_fixture("/api/createDomain/created.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the registration attempt is invalid.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 402](/v2#payment-required) if the account has outstanding payments.
 
 
 ## Retrieve a domain {#getDomain}
@@ -164,6 +171,10 @@ Responds with HTTP 200, renders the domain.
 ~~~json
 <%= pretty_print_fixture("/api/getDomain/success.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Delete a domain {#deleteDomain}
@@ -204,3 +215,9 @@ Delete the domain `example.com` in the account `1010`:
 ### Response
 
 Responds with HTTP 204 on success.
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the domain cannot be deleted.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/domains/collaborators.markdown
+++ b/content/v2/domains/collaborators.markdown
@@ -37,6 +37,10 @@ Responds with HTTP 200.
 <%= pretty_print_fixture("/api/listCollaborators/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
 
 ## Add a collaborator {#addDomainCollaborator}
 
@@ -96,9 +100,11 @@ When the collaborator doesn't have a DNSimple account:
 
 Responds with HTTP 201 on success.
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the collaborator cannot be added.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Remove a collaborator {#removeDomainCollaborator}
@@ -126,6 +132,8 @@ Remove a collaborator `100` from the domain `example.com` in the account `1010`:
 
 Responds with HTTP 204 on success.
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the collaborator cannot be removed
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/domains/dnssec.markdown
+++ b/content/v2/domains/dnssec.markdown
@@ -44,6 +44,11 @@ Responds with HTTP 201.
 <%= pretty_print_fixture("/api/enableDnssec/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if DNSSEC cannot be enabled for the domain.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Disable DNSSEC {#disableDomainDnssec}
 
@@ -71,6 +76,11 @@ Disable DNSSEC for the domain `example.com` in the account `1010`:
 
 Responds with HTTP 204 (No content). Or HTTP 428 if DNSSEC is not currently enabled.
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if DNSSEC cannot be disabled for the domain.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Retrieve DNSSEC status {#getDomainDnssec}
 
@@ -101,6 +111,9 @@ Responds with HTTP 200.
 <%= pretty_print_fixture("/api/getDnssec/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## List delegation signer records {#listDomainDelegationSignerRecords}
 
@@ -114,6 +127,17 @@ Name | Type | Description
 -----|------|------------
 `:account` | `integer` | The account id
 `:domain` | `string`, `integer` | The domain name or id
+
+### Sorting
+
+For general information about sorting, please refer to the [main guide](/v2/#sorting).
+
+Name | Description
+-----|------------
+`id` | Sort delegation signer records by ID
+`created_at` | Sort delegation signer records by creation date
+
+The default sorting policy is by ascending `id`.
 
 ### Example
 
@@ -131,17 +155,9 @@ Responds with HTTP 200.
 <%= pretty_print_fixture("/api/listDelegationSignerRecords/success.http") %>
 ~~~
 
-### Sorting
+### Errors
 
-For general information about sorting, please refer to the [main guide](/v2/#sorting).
-
-Name | Description
------|------------
-`id` | Sort delegation signer records by ID
-`created_at` | Sort delegation signer records by creation date
-
-The default sorting policy is by ascending `id`.
-
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Create a delegation signer record {#createDomainDelegationSignerRecord}
 
@@ -198,10 +214,11 @@ Responds with HTTP 201 on success, renders the delegation signer record.
 <%= pretty_print_fixture("/api/createDelegationSignerRecord/created.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the delegation signer record cannot be created.
 
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Retrieve a delegation signer record {#getDomainDelegationSignerRecord}
 
@@ -231,6 +248,9 @@ Responds with HTTP 200 on success, renders the delegation signer record.
 <%= pretty_print_fixture("/api/getDelegationSignerRecord/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Delete a Delegation Signer record {#deleteDomainDelegationSignerRecord}
 
@@ -255,3 +275,9 @@ Get the delegation signer record `1` under the domain `example.com` in the accou
 ### Response
 
 Responds with HTTP 204 on success.
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the delegation signer record cannot be deleted.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/domains/email-forwards.markdown
+++ b/content/v2/domains/email-forwards.markdown
@@ -27,6 +27,18 @@ Name | Type | Description
 `:account` | `integer` | The account id
 `:domain` | `string`, `integer` | The domain name or id
 
+### Sorting
+
+For general information about sorting, please refer to the [main guide](/v2/#sorting).
+
+Name | Description
+-----|------------
+`id` | Sort email forwards by ID
+`from` | Sort email forwards by sender (alphabetical order)
+`to` | Sort email forwards by recipient (alphabetical order)
+
+The default sorting policy is by ascending `id`.
+
 ### Example
 
 List all email forwards for the domain `example.com` in the account `1010`:
@@ -43,18 +55,9 @@ Responds with HTTP 200.
 <%= pretty_print_fixture("/api/listEmailForwards/success.http") %>
 ~~~
 
-### Sorting
+### Errors
 
-For general information about sorting, please refer to the [main guide](/v2/#sorting).
-
-Name | Description
------|------------
-`id` | Sort email forwards by ID
-`from` | Sort email forwards by sender (alphabetical order)
-`to` | Sort email forwards by recipient (alphabetical order)
-
-The default sorting policy is by ascending `id`.
-
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Create an email forward {#createEmailForward}
 
@@ -102,10 +105,11 @@ Responds with HTTP 201 on success, renders the email forward.
 <%= pretty_print_fixture("/api/createEmailForward/created.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the email forward cannot be created.
 
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Retrieve an email forward {#getEmailForward}
 
@@ -134,6 +138,10 @@ Responds with HTTP 200, renders the email forward.
 ~~~json
 <%= pretty_print_fixture("/api/getEmailForward/success.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Delete an email forward {#deleteEmailForward}
@@ -164,3 +172,8 @@ Delete the email forward with ID `1` under the domain `example.com`, in the acco
 
 Responds with HTTP 204 on success.
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the email forward cannot be deleted.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/domains/pushes.markdown
+++ b/content/v2/domains/pushes.markdown
@@ -53,9 +53,11 @@ Responds with HTTP 201 on success, renders the push.
 <%= pretty_print_fixture("/api/initiatePush/success.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the push cannot be initiated.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## List pushes {#listPushes}
 
@@ -85,6 +87,9 @@ Responds with HTTP 200.
 <%= pretty_print_fixture("/api/listPushes/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Accept a push {#acceptPush}
 
@@ -126,9 +131,11 @@ Name | Type | Description
 
 Responds with HTTP 204 on success.
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the push cannot be accepted.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Reject a push {#rejectPush}
@@ -156,6 +163,6 @@ Reject a push for the target account `2020`:
 
 Responds with HTTP 204 on success.
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/identity.markdown
+++ b/content/v2/identity.markdown
@@ -40,3 +40,7 @@ Responds with HTTP 200. Either user or account may be nil, depending on how you 
 ~~~json
 <%= pretty_print_fixture("/api/whoami/success-user.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -47,6 +47,12 @@ Responds with HTTP 200 on success, returns the domain availability information.
 If the domain is premium (`premium: true`), please [check the premium price](#getDomainPrices) before to try to [register](#register), [renew](#renew), [transfer](#transfer).
 </note>
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the domain availability canont be checked.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
 ## Check domain premium price {#getDomainPremiumPrice}
 
 <note>
@@ -147,9 +153,11 @@ Responds with HTTP 200 on success, returns the domain pricing for registration, 
 
 Responds with HTTP 400, if the domain TLD is not supported.
 
-~~~json
-<%= pretty_print_fixture("/api/getDomainPrices/failure.http") %>
-~~~
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the TLD is not supported or the price canont be checked.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Register a domain {#registerDomain}
 
@@ -206,14 +214,21 @@ The `premium_price` can be fetched via the [prices endpoint](#getDomainPrices).
 
 ### Response
 
-Responds with HTTP 201 on success, returns the domain.
+Responds with HTTP 201 when registration was processed and completed.
+
+Responds with HTTP 202 when registration was processed but is pending completion.
 
 ~~~json
 <%= pretty_print_fixture("/api/registerDomain/success.http") %>
 ~~~
 
-Responds with HTTP 400 if the validation fails.
+### Errors
 
+Responds with [HTTP 400](/v2#bad-request) if the domain cannot be registrered.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 402](/v2#payment-required) if the account has outstanding payments.
 
 ## Transfer a domain {#transferDomain}
 
@@ -278,13 +293,19 @@ Name | Type | Description
 
 ### Response
 
-Responds with HTTP 201 on success, returns the domain.
+Responds with HTTP 201 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/transferDomain/success.http") %>
 ~~~
 
-Responds with HTTP 400 if the validation fails.
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the domain transfer cannot be initiated.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 402](/v2#payment-required) if the account has outstanding payments.
 
 
 ## Retrieve a Domain Transfer {#getDomainTransfer}
@@ -315,12 +336,15 @@ curl  -H 'Authorization: Bearer <token>' \
 
 ### Response
 
-Responds with HTTP 200 on success, returns the domain transfer.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/getDomainTransfer/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Cancel a Domain Transfer {#cancelDomainTransfer}
 
@@ -351,12 +375,17 @@ curl  -H 'Authorization: Bearer <token>' \
 
 ### Response
 
-Responds with HTTP 202 on success, returns the domain transfer.
+Responds with HTTP 202 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/cancelDomainTransfer/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the transfer cannot be canceled.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Renew a domain {#renewDomain}
 
@@ -401,14 +430,19 @@ Name | Type | Description
 
 ### Response
 
-Responds with HTTP 201 on success, returns the domain.
+Responds with HTTP 201 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/renewDomain/success.http") %>
 ~~~
 
-Responds with HTTP 400 if the validation fails.
+### Errors
 
+Responds with [HTTP 400](/v2#bad-request) if the domain cannot be renewed.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 402](/v2#payment-required) if the account has outstanding payments.
 
 ## Authorize a domain transfer out {#authorizeDomainTransferOut}
 
@@ -437,4 +471,8 @@ Transfer out the domain `example.com` in the account `1010`:
 
 Responds with HTTP 204 on success.
 
-Responds with HTTP 400 if the validation fails.
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the transfer out cannot be authorized.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/registrar/auto-renewal.markdown
+++ b/content/v2/registrar/auto-renewal.markdown
@@ -38,6 +38,11 @@ Enable auto-renewal for the domain `example.com` in the account `1010`:
 
 Responds with HTTP 204 on success.
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if auto-renewal cannot be enabled.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Disable domain auto-renewal {#disableDomainAutoRenewal}
 
@@ -67,3 +72,9 @@ Disable auto-renewal for the domain `example.com` in the account `1010`:
 ### Response
 
 Responds with HTTP 204 on success.
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if auto-renewal cannot be disabled.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/registrar/delegation.markdown
+++ b/content/v2/registrar/delegation.markdown
@@ -40,6 +40,9 @@ Responds with HTTP 200.
 <%= pretty_print_fixture("/api/getDomainDelegation/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Change domain name servers {#changeDomainDelegation}
 
@@ -80,15 +83,17 @@ Name | Type | Description
 
 ### Response
 
-Responds with HTTP 200 on success, renders the list of name server names.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/changeDomainDelegation/success.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the delegation fails.
+Responds with [HTTP 400](/v2#bad-request) if the name servers cannot be changed.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Delegate to vanity name servers {#changeDomainDelegationToVanity}
@@ -131,11 +136,13 @@ Responds with HTTP 200 on success, renders the list of name server names.
 <%= pretty_print_fixture("/api/changeDomainDelegationToVanity/success.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the delegation fails.
+Responds with [HTTP 400](/v2#bad-request) if the domain cannot be delegated to the vanity name servers.
 
-Responds with HTTP 412 if the feature is not enabled for the account.
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 412](/v2#precondition-failed) if the account doesn't have access to the vanity name servers feature.
 
 ## Dedelegate from vanity name servers {#changeDomainDelegationFromVanity}
 
@@ -165,8 +172,10 @@ Update name servers for the domain `example.com` in the account `1010`:
 
 Responds with HTTP 204 on success.
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the dedelegation fails.
+Responds with [HTTP 400](/v2#bad-request) if the domain cannot be dedelegated from the vanity name servers.
 
-Responds with HTTP 412 if the feature is not enabled for the account.
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 412](/v2#precondition-failed) if the account doesn't have access to the vanity name servers feature.

--- a/content/v2/registrar/whois-privacy.markdown
+++ b/content/v2/registrar/whois-privacy.markdown
@@ -34,13 +34,11 @@ Get the WHOIS privacy for the domain `example.com` in the account `1010`:
 
 ### Response
 
-Responds with HTTP 200 if WHOIS privacy is purchased for the domain.
+Responds with HTTP 200 on success
 
 ~~~json
 <%= pretty_print_fixture("/api/getWhoisPrivacy/success.http") %>
 ~~~
-
-Responds with HTTP 404 if WHOIS privacy is not purchased.
 
 ## Enable WHOIS privacy {#enableWhoisPrivacy}
 
@@ -78,6 +76,14 @@ Responds with HTTP 200 if WHOIS privacy is only enabled because it was purchased
 <%= pretty_print_fixture("/api/enableWhoisPrivacy/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the whois privacy cannot be enabled.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 402](/v2#payment-required) if the account has outstanding payments.
+
 ## Disable WHOIS privacy {#disableWhoisPrivacy}
 
       DELETE /:account/registrar/domains/:domain/whois_privacy
@@ -112,6 +118,12 @@ Responds with HTTP 200 if WHOIS privacy is disabled.
 <%= pretty_print_fixture("/api/disableWhoisPrivacy/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the whois privacy cannot be disabled.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
 ## Renew WHOIS privacy {#renewWhoisPrivacy}
 
 ~~~
@@ -142,8 +154,8 @@ Responds with HTTP 201 if WHOIS privacy is renewed.
 <%= pretty_print_fixture("/api/renewWhoisPrivacy/success.http") %>
 ~~~
 
-Response with HTTP 400, if WHOIS privacy was never purchased for the domain, or if there is another purchase order in progress:
+### Errors
 
-~~~json
-<%= pretty_print_fixture("/api/renewWhoisPrivacy/whois-privacy-not-found.http") %>
-~~~
+Responds with [HTTP 400](/v2#bad-request) if the whois privacy cannot be renewed.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/secondary-dns.markdown
+++ b/content/v2/secondary-dns.markdown
@@ -31,22 +31,6 @@ List primary servers for in the account.
 | ---------- | --------- | -------------- |
 | `:account` | `integer` | The account id |
 
-### Example
-
-List all primary servers in the account `1010`:
-
-    curl  -H 'Authorization: Bearer <token>' \
-          -H 'Accept: application/json' \
-          https://api.dnsimple.com/v2/1010/secondary_dns/primaries
-
-### Response
-
-Responds with HTTP 200.
-
-~~~json
-<%= pretty_print_fixture("/api/listPrimaryServers/success.http") %>
-~~~
-
 ### Sorting
 
 For general information about sorting, please refer to the [main guide](/v2/#sorting).
@@ -57,6 +41,26 @@ For general information about sorting, please refer to the [main guide](/v2/#sor
 | `name` | Sort primary serves by name (alphabetical order) |
 
 The default sorting policy is by ascending `id`.
+
+### Example
+
+List all primary servers in the account `1010`:
+
+    curl  -H 'Authorization: Bearer <token>' \
+          -H 'Accept: application/json' \
+          https://api.dnsimple.com/v2/1010/secondary_dns/primaries
+
+### Response
+
+Responds with HTTP 200 on success.
+
+~~~json
+<%= pretty_print_fixture("/api/listPrimaryServers/success.http") %>
+~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Create a primary server {#createPrimaryServer}
@@ -106,9 +110,11 @@ Responds with HTTP 201 on success, renders the primary server.
 <%= pretty_print_fixture("/api/createPrimaryServer/created.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the primary server cannot be created.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Retrieve a Primary Server {#getPrimaryServer}
@@ -132,12 +138,15 @@ Get the primary server with the ID `1` in the account `1010`:
 
 ### Response
 
-Responds with HTTP 200, renders the primary server.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/getPrimaryServer/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Delete primary server {#removePrimaryServer}
 
@@ -166,7 +175,9 @@ Delete the primary server with ID `1` in the account `1010`:
 
 Responds with HTTP 204 on success.
 
-Responds with HTTP 404 if primary server is not found.
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Link a primary server to a secondary zone {#linkPrimaryServer}
 
@@ -206,17 +217,17 @@ Link the primary server `1` to a secondary zone `example.com` in the account `10
 
 ### Response
 
-Responds with HTTP 200 on success, renders the primary server. The linked zone will be present in the `linked_secondary_zones` attribute.
+Responds with HTTP 200 on success. The linked zone will be present in the `linked_secondary_zones` attribute.
 
 ~~~json
 <%= pretty_print_fixture("/api/linkPrimaryServer/success.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the primary server cannot be linked to the secondary zone.
 
-Responds with HTTP 404 if the zone or the primary server is not found.
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Unlink a primary server from a secondary zone {#unlinkPrimaryServer}
@@ -257,17 +268,17 @@ Unlink the primary server `1` from a secondary zone `example.com` in the account
 
 ### Response
 
-Responds with HTTP 200 on success, renders the primary server.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/unlinkPrimaryServer/success.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the primary server cannot be unlinked from the secondary zone.
 
-Responds with HTTP 404 if the zone or the primary server is not found.
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Create a secondary zone {#createSecondaryZone}
 
@@ -306,15 +317,17 @@ Create a secondary zone in the account `1010`:
 
 ### Response
 
-Responds with HTTP 201 on success, renders the secondary zone. The attribute `secondary` will be true.
+Responds with HTTP 201 on success. The attribute `secondary` will be true.
 
 ~~~json
 <%= pretty_print_fixture("/api/createSecondaryZone/created.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the secondary zone cannot be created.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Delete secondary zone {#removeSecondaryZone}
 

--- a/content/v2/services.markdown
+++ b/content/v2/services.markdown
@@ -23,20 +23,6 @@ Please refer to the definition of the `ServiceSetting` data type in [our OpenAPI
 
     GET /services
 
-### Example
-
-List all services.
-
-    curl -H 'Authorization: Bearer <token>' \
-         -H 'Accept: application/json' \
-         https://api.dnsimple.com/v2/services
-
-### Response
-
-~~~json
-<%= pretty_print_fixture("/api/listServices/success.http") %>
-~~~
-
 ### Sorting
 
 For general information about sorting, please refer to the [main guide](/v2/#sorting).
@@ -48,6 +34,25 @@ Name | Description
 
 The default sorting policy is by ascending `id`.
 
+### Example
+
+List all services.
+
+    curl -H 'Authorization: Bearer <token>' \
+         -H 'Accept: application/json' \
+         https://api.dnsimple.com/v2/services
+
+### Response
+
+Responds with HTTP 200 on success.
+
+~~~json
+<%= pretty_print_fixture("/api/listServices/success.http") %>
+~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Retrieve a service {#getService}
 
@@ -69,6 +74,12 @@ Get the service with ID `1`.
 
 ### Response
 
+Responds with HTTP 200 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/getService/success.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/services/domains.markdown
+++ b/content/v2/services/domains.markdown
@@ -34,9 +34,15 @@ List applied services for domain with ID `1` in the account `1010`:
 
 ### Response
 
+Responds with HTTP 200 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/appliedServices/success.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Apply a service {#applyServiceToDomain}
 
@@ -77,6 +83,11 @@ Name | Type | Description
 
 Responds with HTTP 204 on success.
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the service cannot be applied to the domain.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Unapply a service {#unapplyServiceFromDomain}
 
@@ -108,3 +119,9 @@ curl -H 'X-DNSimple-Token: <email>:<token>' \
 ### Response
 
 Responds with HTTP 204 on success.
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the service cannot be unapplied.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/templates.markdown
+++ b/content/v2/templates.markdown
@@ -26,22 +26,6 @@ Name | Type | Description
 -----|------|------------
 `:account` | `integer` | The account id
 
-### Example
-
-List all templates in the account `1010`:
-
-    curl  -H 'Authorization: Bearer <token>' \
-          -H 'Accept: application/json' \
-          https://api.dnsimple.com/v2/1010/templates
-
-### Response
-
-Responds with HTTP 200.
-
-~~~json
-<%= pretty_print_fixture("/api/listTemplates/success.http") %>
-~~~
-
 ### Sorting
 
 For general information about sorting, please refer to the [main guide](/v2/#sorting).
@@ -53,6 +37,26 @@ Name | Description
 `sid` | Sort templates by string ID (alphabetical order)
 
 The default sorting policy is by ascending `id`.
+
+### Example
+
+List all templates in the account `1010`:
+
+    curl  -H 'Authorization: Bearer <token>' \
+          -H 'Accept: application/json' \
+          https://api.dnsimple.com/v2/1010/templates
+
+### Response
+
+Responds with HTTP 200 on success.
+
+~~~json
+<%= pretty_print_fixture("/api/listTemplates/success.http") %>
+~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Create a template {#createTemplate}
@@ -102,7 +106,11 @@ Responds with HTTP 201 on success.
 <%= pretty_print_fixture("/api/createTemplate/created.http") %>
 ~~~
 
-Responds with HTTP 400 if the validation fails.
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the template cannot be created.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Retrieve a template {#getTemplate}
@@ -132,10 +140,15 @@ Get the template with short name `example` in the account `1010`:
 
 ### Response
 
+Responds with HTTP 200 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/getTemplate/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Update a template {#updateTemplate}
 
@@ -180,8 +193,11 @@ Responds with HTTP 200 on success.
 <%= pretty_print_fixture("/api/updateTemplate/success.http") %>
 ~~~
 
-Responds with HTTP 400 if the validation fails.
+### Errors
 
+Responds with [HTTP 400](/v2#bad-request) if the template cannot be updated.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Delete a template {#deleteTemplate}
 
@@ -213,3 +229,9 @@ Delete the template with short name `example` in the account `1010`:
 ### Response
 
 Responds with HTTP 204 on success.
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the template cannot be deleted.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/templates/domains.markdown
+++ b/content/v2/templates/domains.markdown
@@ -41,3 +41,8 @@ curl  -H 'Authorization: Bearer <token>' \
 
 Responds with HTTP 204 on success.
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the template cannot be applied to the domain.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/templates/records.markdown
+++ b/content/v2/templates/records.markdown
@@ -25,22 +25,6 @@ Name | Type | Description
 `:account` | `integer` | The account id
 `:template` | `integer` or `string` | The template id or short name
 
-### Example
-
-List records for the template `alpha` in the account `1010`:
-
-    curl  -H 'Authorization: Bearer <token>' \
-          -H 'Accept: application/json' \
-          https://api.dnsimple.com/v2/1010/templates/alpha/records
-
-### Response
-
-Responds with HTTP 200.
-
-~~~json
-<%= pretty_print_fixture("/api/listTemplateRecords/success.http") %>
-~~~
-
 ### Sorting
 
 For general information about sorting, please refer to the [main guide](/v2/#sorting).
@@ -54,6 +38,25 @@ Name | Description
 
 The default sorting policy is by ascending `id`.
 
+### Example
+
+List records for the template `alpha` in the account `1010`:
+
+    curl  -H 'Authorization: Bearer <token>' \
+          -H 'Accept: application/json' \
+          https://api.dnsimple.com/v2/1010/templates/alpha/records
+
+### Response
+
+Responds with HTTP 200 on success.
+
+~~~json
+<%= pretty_print_fixture("/api/listTemplateRecords/success.http") %>
+~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Create a template record {#createTemplateRecord}
 
@@ -107,9 +110,11 @@ Responds with HTTP 201 on success.
 <%= pretty_print_fixture("/api/createTemplateRecord/created.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the template record cannot be created.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Get a template record {#getTemplateRecord}
@@ -134,10 +139,15 @@ Get the record `301` for the template `alpha` in the account `1010`:
 
 ### Response
 
+Responds with HTTP 200 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/getTemplateRecord/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Delete a template record {#deleteTemplateRecord}
 
@@ -165,3 +175,8 @@ Delete the record with ID `301` for template `alpha` in the account `1010`:
 
 Responds with HTTP 204 on success.
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the template record cannot be deleted.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/tlds.markdown
+++ b/content/v2/tlds.markdown
@@ -30,6 +30,16 @@ Returns the list of TLDs supported for registration or transfer.
 GET /tlds
 ~~~
 
+### Sorting
+
+For general information about sorting, please refer to the [main guide](/v2/#sorting).
+
+Name | Description
+-----|------------
+`tld` | Sort TLDs by tld
+
+The default sorting policy is by ascending `tld`.
+
 ### Example
 
 List all TLDs.
@@ -46,15 +56,9 @@ curl -H 'Authorization: Bearer <token>' \
 <%= pretty_print_fixture("/api/listTlds/success.http") %>
 ~~~
 
-### Sorting
+### Errors
 
-For general information about sorting, please refer to the [main guide](/v2/#sorting).
-
-Name | Description
------|------------
-`tld` | Sort TLDs by tld
-
-The default sorting policy is by ascending `tld`.
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Retrieve the TLD {#getTld}
@@ -87,6 +91,9 @@ curl -H 'Authorization: Bearer <token>' \
 <%= pretty_print_fixture("/api/getTld/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Lists the TLD Extended Attributes {#getTldExtendedAttributes}
 
@@ -120,3 +127,7 @@ curl -H 'Authorization: Bearer <token>' \
 ~~~json
 <%= pretty_print_fixture("/api/getTldExtendedAttributes/success.http") %>
 ~~~
+
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/vanity.markdown
+++ b/content/v2/vanity.markdown
@@ -46,7 +46,15 @@ Responds with HTTP 200 on success.
 <%= pretty_print_fixture("/api/enableVanityNameServers/success.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if vanity name servers cannot be enabled.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 402](/v2#payment-required) if the account has outstanding payments.
+
+Responds with [HTTP 412](/v2#precondition-failed) if the account doesn't have access to the vanity name server feature.
 
 
 ## Disable vanity name servers {#disableVanityNameServers}
@@ -77,4 +85,12 @@ Enable Vanity Name Servers for the domain `example.com` in the account `1010`:
 
 Responds with HTTP 204 on success.
 
-Responds with HTTP 400 if bad request.
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if vanity name servers cannot be disabled.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 402](/v2#payment-required) if the account has outstanding payments.
+
+Responds with [HTTP 412](/v2#precondition-failed) if the account doesn't have access to the vanity name server feature.

--- a/content/v2/webhooks/webhooks.markdown
+++ b/content/v2/webhooks/webhooks.markdown
@@ -25,6 +25,16 @@ Name | Type | Description
 -----|------|------------
 `:account` | `integer` | The account id
 
+### Sorting
+
+For general information about sorting, please refer to the [main guide](/v2/#sorting).
+
+Name | Description
+-----|------------
+`id` | Sort webhooks by ID
+
+The default sorting policy is by ascending `id`.
+
 ### Example
 
 List all webhooks in the account `1010`:
@@ -35,21 +45,15 @@ List all webhooks in the account `1010`:
 
 ### Response
 
-Responds with HTTP 200.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/listWebhooks/success.http") %>
 ~~~
 
-### Sorting
+### Errors
 
-For general information about sorting, please refer to the [main guide](/v2/#sorting).
-
-Name | Description
------|------------
-`id` | Sort webhooks by ID
-
-The default sorting policy is by ascending `id`.
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Create a webhook {#createWebhook}
@@ -95,7 +99,11 @@ Responds with HTTP 201 on success.
 <%= pretty_print_fixture("/api/createWebhook/created.http") %>
 ~~~
 
-Responds with HTTP 400 if the validation fails.
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the webhook cannot be created.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Retrieve a webhook {#getWebhook}
@@ -120,10 +128,15 @@ Get the webhook with ID `1` in the account `1010`:
 
 ### Response
 
+Responds with HTTP 200 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/getWebhook/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Delete a webhook {#deleteWebhook}
 
@@ -148,3 +161,9 @@ Delete the webhook with ID `1` in the account `1010`:
 ### Response
 
 Responds with HTTP 204 on success.
+
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the webhook cannot be deleted.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.

--- a/content/v2/zones.markdown
+++ b/content/v2/zones.markdown
@@ -61,12 +61,15 @@ List all zones in the account `1010` that have name matching `"example"`:
 
 ### Response
 
-Responds with HTTP 200.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/listZones/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Retrieve a zone {#getZone}
 
@@ -91,12 +94,15 @@ Get the zone `example.com` in the account `1010`:
 
 ### Response
 
-Responds with HTTP 200, renders the zone.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/getZone/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Download a zone file {#getZoneFile}
 
@@ -119,12 +125,15 @@ Get the zone file `example.com` in the account `1010`:
 
 ### Response
 
-Responds with HTTP 200, renders the zone file.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/getZoneFile/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Check zone distribution {#checkZoneDistribution}
 
@@ -165,7 +174,11 @@ Responds with HTTP 200 when the zone is not distributed.
 <%= pretty_print_fixture("/api/checkZoneDistribution/failure.http") %>
 ~~~
 
-Responds with HTTP 504 when the server failed to perform the check.
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 504](/v2/#gateway-timeout) when the server failed to perform the check.
 
 ~~~json
 <%= pretty_print_fixture("/api/checkZoneDistribution/error.http") %>

--- a/content/v2/zones/records.markdown
+++ b/content/v2/zones/records.markdown
@@ -94,12 +94,15 @@ curl  -H 'Authorization: Bearer <token>' \
 
 ### Response
 
-Responds with HTTP 200.
+Responds with HTTP 200 on success.
 
 ~~~json
 <%= pretty_print_fixture("/api/listZoneRecords/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Create a zone record {#createZoneRecord}
 
@@ -159,9 +162,11 @@ Responds with HTTP 201 on success.
 <%= pretty_print_fixture("/api/createZoneRecord/created.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the record cannot be created.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 
 ## Retrieve a zone record {#getZoneRecord}
@@ -190,10 +195,15 @@ curl  -H 'Authorization: Bearer <token>' \
 
 ### Response
 
+Responds with HTTP 200 on success.
+
 ~~~json
 <%= pretty_print_fixture("/api/getZoneRecord/success.http") %>
 ~~~
 
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Update a zone record {#updateZoneRecord}
 
@@ -253,10 +263,11 @@ Responds with HTTP 200 on success.
 <%= pretty_print_fixture("/api/updateZoneRecord/success.http") %>
 ~~~
 
-Responds with HTTP 400 if bad request.
+### Errors
 
-Responds with HTTP 400 if the validation fails.
+Responds with [HTTP 400](/v2#bad-request) if the record cannot be updated.
 
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Delete a zone record {#deleteZoneRecord}
 
@@ -288,6 +299,11 @@ curl  -H 'Authorization: Bearer <token>' \
 
 Responds with HTTP 204 on success.
 
+### Errors
+
+Responds with [HTTP 400](/v2#bad-request) if the record cannot be deleted.
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
 
 ## Check zone record distribution {#checkZoneRecordDistribution}
 
@@ -331,7 +347,11 @@ Responds with HTTP 200 when the zone record is not distributed.
 <%= pretty_print_fixture("/api/checkZoneRecordDistribution/failure.http") %>
 ~~~
 
-Responds with HTTP 504 when the server failed to perform the check.
+### Errors
+
+Responds with [HTTP 401](/v2#unauthorized) in case of case of authentication issues.
+
+Responds with [HTTP 504](/v2#gateway-timeout) when the server failed to perform the check.
 
 ~~~json
 <%= pretty_print_fixture("/api/checkZoneRecordDistribution/error.http") %>


### PR DESCRIPTION
This is an initial effort towards better documenting the errors our API returns. To do this we are:

1. Extending the existing section in the overview about errors. We are including specific error codes we use along examples of the different payloads to expect for each error type.
2. Creating an error sub-section for each endpoint in which we list the most relevant error codes the endpoint may return.
  - For now, we are leaving out generic errors like `404` and `429` that affect all endpoints. We are including 401, to make sure there is always an error section.
  - For each error type we are cross-linking the overview section about errors.

I have also made some edits to improve the consistency overall, including some wording and the section ordering.
