### PR TITLE
Document new optional input parameter in the certificates endpoint

### DIFF
--- a/content/v2/certificates.markdown
+++ b/content/v2/certificates.markdown
@@ -217,6 +217,10 @@ Certificates with auto-renewal disabled may be [renewed manually](#purchaseRenew
 
 You may also **purchase the certificate once** and select the auto-renewal option. With auto-renewal enabled, our system automatically renews a certificate before it expires. Notifications for renewed certificates are sent via email, and a webhook is fired when a new certificate is available. You'll still have to install the renewed certificate.
 
+### Signature algorithm
+
+By default, a certificate will be signed using `ECC` keys, but `RSA` can be used as well if your specific scenario required it.
+
 ### Parameters
 
 Name | Type | Description
@@ -243,6 +247,7 @@ Name | Type | Description
 `auto_renew` | `bool` | Set to true to enable the auto-renewal of the certificate. Default: `false`.
 `name` | `string` | The certificate name. Default: `"www"`.
 `alternate_names` | `array<string>` | The certificate _alternate names_. Default: `[]`. Example: `["docs.example.com", "status.example.com"]`
+`signature_algorithm` | `string` | Optional string to determine the signature algorithm to be used. Either `ECDSA` or `RSA`, defaults to `ECDSA`. 
 
 ### Response
 
@@ -321,6 +326,10 @@ You must renew a certificate **only** if it does **NOT** use the **auto renewal*
 
 You can always enable or disable _auto renewal_ when renewing a certificate.
 
+### Signature algorithm
+
+By default, a certificate will be signed using `ECC` keys, but `RSA` can be used as well if your specific scenario required it.
+
 ### Parameters
 
 Name | Type | Description
@@ -346,6 +355,7 @@ Renew a Let's Encrypt certificate with ID `101967` for `bingo.pizza` in the acco
 Name | Type | Description
 -----|------|------------
 `auto_renew` | `bool` | Set to true to enable the auto-renewal of the certificate. Default: `false`.
+`signature_algorithm` | `string` | Optional string to determine the signature algorithm to be used. Either `ECDSA` or `RSA`, defaults to `ECDSA`.
 
 ### Response
 

--- a/content/v2/certificates.markdown
+++ b/content/v2/certificates.markdown
@@ -219,7 +219,7 @@ You may also **purchase the certificate once** and select the auto-renewal optio
 
 ### Signature algorithm
 
-By default, a certificate will be signed using `ECC` keys, but `RSA` can be used as well if your specific scenario required it.
+By default, a certificate uses `ECDSA` signature algorithm, but `RSA` can be used as well if your specific scenario required it.
 
 ### Parameters
 
@@ -328,7 +328,7 @@ You can always enable or disable _auto renewal_ when renewing a certificate.
 
 ### Signature algorithm
 
-By default, a certificate will be signed using `ECC` keys, but `RSA` can be used as well if your specific scenario required it.
+By default, a certificate uses `ECDSA` signature algorithm, but `RSA` can be used as well if your specific scenario required it.
 
 ### Parameters
 

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -690,6 +690,36 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Domain'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: 
+                auto_renew:
+                  description: 'Enable the auto-renewal of the certificate'
+                  type: boolean
+                  required: false
+                  default: false
+                name:
+                  description: 'The certificate name'
+                  type: string
+                  required: false
+                  default: 'www'
+                alternate_names:
+                  description: 'The certificate alternate names'
+                  type: array
+                  items:
+                    type: string
+                  required: false
+                  default: []
+                  example: ['docs.example.com', 'status.example.com']
+                signature_algorithm:
+                  description: 'Optional string to determine the signature algorithm to be used. Either `ECDSA` or `RSA`'
+                  type: string
+                  required: false
+                  default: 'ECDSA'
       operationId: purchaseLetsencryptCertificate
       tags:
         - domain certificates
@@ -744,6 +774,23 @@ paths:
       operationId: purchaseRenewalLetsencryptCertificate
       tags:
         - domain certificates
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                auto_renew:
+                  description: 'Enable the auto-renewal of the certificate'
+                  type: boolean
+                  required: false
+                  default: false
+                signature_algorithm:
+                  description: 'Optional string to determine the signature algorithm to be used. Either `ECDSA` or `RSA`'
+                  type: string
+                  required: false
+                  default: 'ECDSA'
       responses:
         '201':
           description: Successfully created the certificate renewal order.


### PR DESCRIPTION
In this PR:
- Document the new `signature_algorithm` input parameter in the certificates endpoint
- Add `requestBody` OpenAPI sections for the affected endpoints to document the change.