### PR TITLE
Add OpenAPI entries for the new entrypoint to toggle DNS resolution on a zone

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -124,7 +124,7 @@ paths:
         Creates a domain and the corresponding zone into the account.
 
         When creating a domain using Solo or Teams subscription, the resolution
-        for the zone will be **automatically enabled and this will be charged** on your
+        for the zone will be automatically enabled and this will be charged on your
         following subscription renewal invoices.
       parameters:
         - $ref: '#/components/parameters/Account'
@@ -1558,7 +1558,7 @@ paths:
         Creates a secondary zone into the account.
 
         When creating a secondary zone using Solo or Teams subscription, the resolution
-        for the zone will be **automatically enabled and this will be charged** on your
+        for the zone will be automatically enabled and this will be charged on your
         following subscription renewal invoices.
       parameters:
         - $ref: '#/components/parameters/Account'
@@ -1853,7 +1853,7 @@ paths:
       description: |-
         Enables DNS resolution for the zone.
 
-        Under Solo and Teams plans, **active zones are charged when renewing your subscription** to
+        Under Solo and Teams plans, active zones are charged when renewing your subscription to
         DNSimple
       parameters:
         - $ref: '#/components/parameters/Account'
@@ -1878,7 +1878,7 @@ paths:
       description: |-
         Disables DNS resolution for the zone.
 
-        Under Solo and Teams plans, **active zones are charged when renewing your subscription** to
+        Under Solo and Teams plans, active zones are charged when renewing your subscription to
         DNSimple
       parameters:
         - $ref: '#/components/parameters/Account'

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1838,6 +1838,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       summary: Check zone record distribution
+  '/{account}/zones/{zone}/resolution':
+    put:
+      description: Enables DNS resolution on the zone
+      parameters:
+        - $ref: '#/components/parameters/Account'
+        - $ref: '#/components/parameters/Zone'
+      operationId: enableZoneResolution
+      tags:
+        - zones
+      responses:
+        '200':
+          description: Successfully enabled DNS resolution on the zone.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Zone'
+        '404':
+          $ref: '#/components/responses/404'
+      summary: Enable a zone's DNS resolution
+    delete:
+      description: Disables DNS resolution on the zone
+      parameters:
+        - $ref: '#/components/parameters/Account'
+        - $ref: '#/components/parameters/Zone'
+      operationId: disableZoneResolution
+      tags:
+        - zones
+      responses:
+        '200':
+          description: Successfully disabled DNS resolution on the zone.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Zone'
+        '404':
+          $ref: '#/components/responses/404'
+      summary: Disable a zone's DNS resolution
   '/{account}/contacts':
     get:
       description: List contacts in the account.

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -120,7 +120,12 @@ paths:
           description: Domain listing.
     post:
       summary: Create a domain
-      description: Creates a domain and the corresponding zone into the account.
+      description: |-
+        Creates a domain and the corresponding zone into the account.
+
+        When creating a domain using Solo or Teams subscription, the resolution
+        for the zone will be **automatically enabled and this will be charged** on your
+        following subscription renewal invoices.
       parameters:
         - $ref: '#/components/parameters/Account'
       operationId: createDomain
@@ -1840,9 +1845,11 @@ paths:
       summary: Check zone record distribution
   '/{account}/zones/{zone}/resolution':
     put:
-      description: When creating a zone under Solo and Teams plan using the API it will be
-        activated automatically. This endpoint allows to activate the DNS resolution for the
-        zone programatically.
+      description: |-
+        Enables DNS resolution for the zone.
+
+        Under Solo and Teams plans, **active zones are charged when renewing your subscription** to
+        DNSimple
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Zone'
@@ -1863,9 +1870,11 @@ paths:
           $ref: '#/components/responses/404'
       summary: Enable a zone's DNS resolution
     delete:
-      description: When creating a zone under Solo and Teams plan using the API it will be
-        activated automatically. This endpoint allows to deactivate the DNS resolution for the
-        zone programatically.
+      description: |-
+        Disables DNS resolution for the zone.
+
+        Under Solo and Teams plans, **active zones are charged when renewing your subscription** to
+        DNSimple
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Zone'

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1871,7 +1871,7 @@ paths:
         - zones
       responses:
         '200':
-          description: Successfully enabled DNS resolution on the zone.
+          description: Successful activation of DNS services on the zone.
           content:
             application/json:
               schema:

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1866,7 +1866,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Zone'
-      operationId: activatezoneResolution
+      operationId: activateZoneService
       tags:
         - zones
       responses:
@@ -1891,7 +1891,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Zone'
-      operationId: deactivateZoneResolution
+      operationId: deactivateZoneService
       tags:
         - zones
       responses:

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -990,6 +990,10 @@ paths:
         Registers a domain name.
 
         Your account must be active for this command to complete successfully. You will be automatically charged the registration fee upon successful registration, so please be careful with this command.
+
+        When registering a domain using Solo or Teams subscription, the resolution
+        for the zone will be automatically enabled and this will be charged on your
+        following subscription renewal invoices.
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Domain'
@@ -1041,6 +1045,10 @@ paths:
         Transfers a domain name from another registrar.
 
         Your account must be active for this command to complete successfully. You will be automatically charged the 1-year transfer fee upon successful transfer, so please be careful with this command. The transfer may take anywhere from a few minutes up to 7 days.
+
+        When transfering a domain using Solo or Teams subscription, the resolution
+        for the zone will be automatically enabled and this will be charged on your
+        following subscription renewal invoices.
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Domain'

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1840,7 +1840,9 @@ paths:
       summary: Check zone record distribution
   '/{account}/zones/{zone}/resolution':
     put:
-      description: Enables DNS resolution on the zone
+      description: When creating a zone under Solo and Teams plan using the API it will be
+        activated automatically. This endpoint allows to activate the DNS resolution for the
+        zone programatically.
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Zone'
@@ -1861,7 +1863,9 @@ paths:
           $ref: '#/components/responses/404'
       summary: Enable a zone's DNS resolution
     delete:
-      description: Disables DNS resolution on the zone
+      description: When creating a zone under Solo and Teams plan using the API it will be
+        activated automatically. This endpoint allows to deactivate the DNS resolution for the
+        zone programatically.
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Zone'

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1866,7 +1866,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Zone'
-      operationId: enableZoneResolution
+      operationId: activatezoneResolution
       tags:
         - zones
       responses:
@@ -1881,7 +1881,7 @@ paths:
                     $ref: '#/components/schemas/Zone'
         '404':
           $ref: '#/components/responses/404'
-      summary: Enable a zone's DNS resolution
+      summary: Activate a zone DNS service
     delete:
       description: |-
         Deactivates DNS services for the zone.
@@ -1891,12 +1891,12 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Account'
         - $ref: '#/components/parameters/Zone'
-      operationId: disableZoneResolution
+      operationId: deactivateZoneResolution
       tags:
         - zones
       responses:
         '200':
-          description: Successfully disabled DNS resolution on the zone.
+          description: Successfully deactivate DNS resolution on the zone.
           content:
             application/json:
               schema:
@@ -1906,7 +1906,7 @@ paths:
                     $ref: '#/components/schemas/Zone'
         '404':
           $ref: '#/components/responses/404'
-      summary: Disable a zone's DNS resolution
+      summary: Deactivate a zone DNS service
   '/{account}/contacts':
     get:
       description: List contacts in the account.

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1859,7 +1859,7 @@ paths:
   '/{account}/zones/{zone}/resolution':
     put:
       description: |-
-        Enables DNS resolution for the zone.
+        Activate DNS services for the zone.
 
         Under Solo and Teams plans, active zones are charged when renewing your subscription to
         DNSimple

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1884,7 +1884,7 @@ paths:
       summary: Enable a zone's DNS resolution
     delete:
       description: |-
-        Disables DNS resolution for the zone.
+        Deactivates DNS services for the zone.
 
         Under Solo and Teams plans, active zones are charged when renewing your subscription to
         DNSimple

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1554,7 +1554,12 @@ paths:
   '/{account}/secondary_dns/zones':
     post:
       summary: Create a secondary zone
-      description: Creates a secondary zone into the account.
+      description: |-
+        Creates a secondary zone into the account.
+
+        When creating a secondary zone using Solo or Teams subscription, the resolution
+        for the zone will be **automatically enabled and this will be charged** on your
+        following subscription renewal invoices.
       parameters:
         - $ref: '#/components/parameters/Account'
       operationId: createSecondaryZone


### PR DESCRIPTION
This PR adds new entries for new entry points that will enable our users to enable and disable DNS resolution on the provided zone (yet to be released)

Belongs to https://github.com/dnsimple/dnsimple-business/pull/1713