### PR TITLE
OpenAPI: Simplify sandbox server description

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -18,7 +18,7 @@ servers:
     description: DNSimple Production API
     variables: {}
   - url: 'https://api.sandbox.dnsimple.com/v2'
-    description: 'DNSimple Sandbox API.'
+    description: 'DNSimple Sandbox API used for testing'
 tags:
   - name: accounts
   - name: contacts

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -18,7 +18,7 @@ servers:
     description: DNSimple Production API
     variables: {}
   - url: 'https://api.sandbox.dnsimple.com/v2'
-    description: 'DNSimple Sandbox API. For more information on the purpose and use of the Sandbox API, see our [testing documentation](https://developer.dnsimple.com/v2/#testing)'
+    description: 'DNSimple Sandbox API.'
 tags:
   - name: accounts
   - name: contacts


### PR DESCRIPTION
[While the server object allows Markdown](https://swagger.io/specification/#server-object), it seems many integrations would not parse the description as such and instead prefers a shorter version.

<img width="1483" alt="Screenshot 2023-07-06 at 11 43 14" src="https://github.com/dnsimple/dnsimple-developer/assets/5387/db484240-3e79-490b-b714-4ef779d91ab1">
