### PR TITLE
Document stateful trade webhooks

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3861,7 +3861,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/NameServer'
-    EventDomainRegistrantStarted:
+    EventDomainRegistrantChangeStarted:
       type: object
       description: Payload for domain.registrant_change:started
       properties:

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3861,9 +3861,25 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/NameServer'
+    EventDomainRegistrantStarted:
+      type: object
+      description: Payload for domain.registrant_change:started
+      properties:
+        domain:
+          $ref: '#/components/schemas/Domain'
+        registrant:
+          $ref: '#/components/schemas/Contact'
     EventDomainRegistrantChange:
       type: object
       description: Payload for domain.registrant_change
+      properties:
+        domain:
+          $ref: '#/components/schemas/Domain'
+        registrant:
+          $ref: '#/components/schemas/Contact'
+    EventDomainRegistrantChangeCancelled:
+      type: object
+      description: Payload for domain.registrant_change:cancelled
       properties:
         domain:
           $ref: '#/components/schemas/Domain'
@@ -4791,7 +4807,9 @@ components:
             - domain.renew
             - 'domain.renew:cancelled'
             - domain.delegation_change
+            - 'domain.registrant_change:started'
             - domain.registrant_change
+            - 'domain.registrant_change:cancelled'
             - domain.resolution_disable
             - domain.resolution_enable
             - 'domain.transfer:started'
@@ -4876,7 +4894,9 @@ components:
             - $ref: '#/components/schemas/EventDomainRenew'
             - $ref: '#/components/schemas/EventDomainRenewCancelled'
             - $ref: '#/components/schemas/EventDomainDelegationChange'
+            - $ref: '#/components/schemas/EventDomainRegistrantChangeStarted'
             - $ref: '#/components/schemas/EventDomainRegistrantChange'
+            - $ref: '#/components/schemas/EventDomainRegistrantChangeCancelled'
             - $ref: '#/components/schemas/EventDomainResolutionDisable'
             - $ref: '#/components/schemas/EventDomainResolutionEnable'
             - $ref: '#/components/schemas/EventDomainTransferStarted'

--- a/content/v2/webhooks/events.markdown
+++ b/content/v2/webhooks/events.markdown
@@ -97,7 +97,9 @@ The following events are available:
 * domain.renew
 * domain.renew:cancelled
 * domain.delegation\_change
+* domain.registrant\_change:started
 * domain.registrant\_change
+* domain.registrant\_change:cancelled
 * domain.resolution\_disable
 * domain.resolution\_enable
 * domain.transfer:started

--- a/fixtures/v2/webhooks/domain.registrant_change/status-cancelled.http
+++ b/fixtures/v2/webhooks/domain.registrant_change/status-cancelled.http
@@ -1,0 +1,9 @@
+POST / HTTP/1.1
+Host: example.com
+Accept-Encoding: gzip
+Content-Type: application/json
+User-Agent: DNSimple-Webhook-Notifier/8fd98a84516b72d5b863b27f93fcbaef61f06c03
+Content-Length: 1070
+Connection: keep-alive
+
+{"data": {"domain": {"id": 181984, "name": "example-alpha.com", "state": "registered", "account_id": 1385, "auto_renew": false, "created_at": "2020-06-04T19:15:14Z", "expires_at": "2021-06-05T02:15:00Z", "expires_on": "2021-06-05", "updated_at": "2020-06-04T21:04:17Z", "unicode_name": "example-alpha.com", "private_whois": false, "registrant_id": 2716}, "registrant": {"id": 2716, "fax": "", "city": "New York", "label": "new_contact", "phone": "+1 202-555-0191", "country": "US", "address1": "Test St", "address2": "", "job_title": "", "last_name": "Corp 2", "account_id": 1385, "created_at": "2020-06-04T21:03:47.226Z", "first_name": "DNSimple", "updated_at": "2020-06-04T21:03:47.226Z", "postal_code": "14801", "email_address": "support@dnsimple.com", "state_province": "NY", "organization_name": ""}}, "name": "domain.registrant_change:cancelled", "actor": {"id": "1331", "entity": "user", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1385, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "9ef5f6f7-fa00-4d31-a1dc-5f80ae783d93"}

--- a/fixtures/v2/webhooks/domain.registrant_change/status-started.http
+++ b/fixtures/v2/webhooks/domain.registrant_change/status-started.http
@@ -1,0 +1,9 @@
+POST / HTTP/1.1
+Host: example.com
+Accept-Encoding: gzip
+Content-Type: application/json
+User-Agent: DNSimple-Webhook-Notifier/8fd98a84516b72d5b863b27f93fcbaef61f06c03
+Content-Length: 1070
+Connection: keep-alive
+
+{"data": {"domain": {"id": 181984, "name": "example-alpha.com", "state": "registered", "account_id": 1385, "auto_renew": false, "created_at": "2020-06-04T19:15:14Z", "expires_at": "2021-06-05T02:15:00Z", "expires_on": "2021-06-05", "updated_at": "2020-06-04T21:04:17Z", "unicode_name": "example-alpha.com", "private_whois": false, "registrant_id": 2716}, "registrant": {"id": 2716, "fax": "", "city": "New York", "label": "new_contact", "phone": "+1 202-555-0191", "country": "US", "address1": "Test St", "address2": "", "job_title": "", "last_name": "Corp 2", "account_id": 1385, "created_at": "2020-06-04T21:03:47.226Z", "first_name": "DNSimple", "updated_at": "2020-06-04T21:03:47.226Z", "postal_code": "14801", "email_address": "support@dnsimple.com", "state_province": "NY", "organization_name": ""}}, "name": "domain.registrant_change:started", "actor": {"id": "1331", "entity": "user", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1385, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "9ef5f6f7-fa00-4d31-a1dc-5f80ae783d93"}


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-business/issues/1709.

## Description
This PR adds the stateful trade webhooks:

- `domain.registrant_change:started`
- `domain.registrant_change:cancelled`

## Tasks

- [ ] Post: Complete task in  https://dnsimple.atlassian.net/wiki/spaces/ACQUISITION/pages/2555248656/Stateful+Trades