### PR TITLE
Update deleteRegistrantChange responses and fixtures

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2123,10 +2123,17 @@ paths:
       tags:
         - registrant changes
       responses:
-        '200':
+        '204':
           description: Successfully cancelled registrant change.
-        '201':
+        '202':
           description: The registrant change is cancelling.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/RegistrantChange'
         '400':
           $ref: '#/components/responses/400'
         '404':

--- a/fixtures/v2/api/deleteRegistrantChange/success.http
+++ b/fixtures/v2/api/deleteRegistrantChange/success.http
@@ -1,4 +1,4 @@
-HTTP/1.1 201
+HTTP/1.1 204 No Content
 server: nginx
 date: Tue, 22 Aug 2023 11:14:44 GMT
 content-type: application/json; charset=utf-8

--- a/fixtures/v2/api/deleteRegistrantChange/success_async.http
+++ b/fixtures/v2/api/deleteRegistrantChange/success_async.http
@@ -1,0 +1,14 @@
+HTTP/1.1 202
+server: nginx
+date: Tue, 22 Aug 2023 11:11:00 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2394
+x-ratelimit-reset: 1692705339
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: 26bf7ff9-2075-42b0-9431-1778c825b6b0
+x-runtime: 3.408950
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"cancelling","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}}


### PR DESCRIPTION
This PR updates the OpenAPI definition for the **deleteRegistrantChange** operation. It changes the responses to:

Before:

- Return 200 with an empty body when a cancellation happens sync
- Return 201 with an empty body when a cancellation is happening async

Now:

- Return 204 with an empty body when a cancellation happens sync
- Return 202 with the registrant change record when a cancellation happens async

Fixtures have been updated to reflect the changes.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1729
Depends on https://github.com/dnsimple/dnsimple-app/pull/23686