### PR TITLE
Add linked provider param to domain registration API

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3608,8 +3608,6 @@ components:
           type: boolean
         whois_privacy:
           type: boolean
-        linked_provider:
-          type: string
         created_at:
           $ref: '#/components/schemas/DateTime'
         updated_at:
@@ -5573,6 +5571,9 @@ components:
               premium_price:
                 type: string
                 description: 'Required as confirmation of the price, only if the domain is premium.'
+              linked_provider:
+                type: string
+                description: 'The nickname of a linked provider to register the domain through. If left blank, registration will go through DNSimple.'
             example:
               registrant_id: 1
     DomainRenew:

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3608,6 +3608,8 @@ components:
           type: boolean
         whois_privacy:
           type: boolean
+        linked_provider:
+          type: string
         created_at:
           $ref: '#/components/schemas/DateTime'
         updated_at:

--- a/content/v2/registrar.markdown
+++ b/content/v2/registrar.markdown
@@ -198,6 +198,7 @@ Name | Type | Description
 -----|------|------------
 `registrant_id` | `integer` | **Required**. The ID of an existing [contact](/v2/contacts/#contact-attributes) in your account.
 `whois_privacy` | `bool` | Set to true will attempt to purchase/enable the whois privacy as part of the registration. An extra cost may apply. Default: `false`.
+`linked_provider` | `string` | When set to the nickname of a linked provider, registration of the domain will go through that provider. Otherwise, registration of the domain will go through DNSimple.
 `auto_renew` | `bool` | Set to true to enable the auto-renewal of the domain. Default: `false`.
 `extended_attributes` | `hash` | **Required** for TLDs that require [extended attributes](/v2/tlds/#getTldExtendedAttributes).
 `premium_price` | `string` | **Required** as confirmation of the price, only if the domain is premium.


### PR DESCRIPTION
This PR adds the `linked_provider` parameter to the domain registration endpoint. If a `linked_provider` param is passed, we register the domain through the given provider. Otherwise, the domain is registered through DNSimple.

As we didn't have time to completely consult the external registrations team as to how the API is designed, I opened this PR to facilitate that discussion. Should we change the design?

FYI, the API endpoint for a domain transfer via a linked provider has not been implemented yet.