### PR TITLE
Fix webapp configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development do
 end
 
 group :nanoc do
-  gem 'guard-nanoc'
+  gem 'nanoc-live'
 end
 
 gem "puma", "~> 6.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,44 +6,36 @@ GEM
     adsf (1.4.8)
       rack (>= 1.0.0, < 4.0.0)
       rackup (~> 2.1)
+    adsf-live (1.4.8)
+      adsf (~> 1.3)
+      em-websocket (~> 0.5)
+      eventmachine (~> 1.2)
+      listen (~> 3.0)
+      rack-livereload (~> 0.3)
     ansi (1.5.0)
     builder (3.2.4)
-    coderay (1.1.3)
     colored (1.2)
     concurrent-ruby (1.2.2)
     cri (2.15.11)
     ddmetrics (1.0.1)
     ddplugin (1.0.3)
     diff-lcs (1.5.0)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
     ffi (1.14.2)
-    formatador (0.2.5)
-    guard (2.16.2)
-      formatador (>= 0.2.4)
-      listen (>= 2.7, < 4.0)
-      lumberjack (>= 1.0.12, < 2.0)
-      nenv (~> 0.1)
-      notiffany (~> 0.0)
-      pry (>= 0.9.12)
-      shellany (~> 0.0)
-      thor (>= 0.18.1)
-    guard-compat (1.2.1)
-    guard-nanoc (2.1.9)
-      guard (~> 2.8)
-      guard-compat (~> 1.0)
-      nanoc-cli (~> 4.11, >= 4.11.14)
-      nanoc-core (~> 4.11, >= 4.11.14)
+    http_parser.rb (0.8.0)
     immutable-ruby (0.1.0)
       concurrent-ruby (~> 1.1)
       sorted_set (~> 1.0)
     json_schema (0.21.0)
     kramdown (2.4.0)
       rexml
-    listen (3.4.1)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    lumberjack (1.2.8)
     memo_wise (1.7.0)
-    method_source (1.0.0)
     mime-types (3.5.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0808)
@@ -87,20 +79,18 @@ GEM
       nanoc-checking (~> 1.0)
       nanoc-cli (~> 4.11, >= 4.11.15)
       nanoc-core (~> 4.11, >= 4.11.15)
-    nenv (0.3.0)
+    nanoc-live (1.0.0)
+      adsf-live (~> 1.4)
+      listen (~> 3.0)
+      nanoc-cli (~> 4.11, >= 4.11.14)
+      nanoc-core (~> 4.11, >= 4.11.14)
     nio4r (2.5.9)
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    notiffany (0.1.3)
-      nenv (~> 0.1)
-      shellany (~> 0.0)
     parallel (1.23.0)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     psych (4.0.6)
       stringio
     public_suffix (5.0.1)
@@ -108,6 +98,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (3.0.8)
+    rack-livereload (0.5.1)
+      rack
     rackup (2.1.0)
       rack (>= 3)
       webrick (~> 1.8)
@@ -125,14 +117,12 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     set (1.0.3)
-    shellany (0.0.1)
     slow_enumerator_tools (1.1.0)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
     stringio (3.0.7)
     systemu (2.6.5)
-    thor (0.20.3)
     tty-color (0.6.0)
     tty-command (0.10.1)
       pastel (~> 0.8)
@@ -147,12 +137,12 @@ PLATFORMS
 DEPENDENCIES
   adsf
   builder
-  guard-nanoc
   kramdown
   mime-types
   minitest
   minitest-reporters
   nanoc (~> 4.12)
+  nanoc-live
   nokogiri
   puma (~> 6.4)
   rake
@@ -161,4 +151,4 @@ DEPENDENCIES
   systemu
 
 BUNDLED WITH
-   2.2.33
+   2.4.22


### PR DESCRIPTION
This PR removes the now deprecated `guard-nanoc` in favor of `nanoc-live` as otherwise, you can't run the app in development.

**Other changes:**
* bump bundler version