### PR TITLE
Dynamically loading the "whats new"

### DIFF
--- a/content/index.html.erb
+++ b/content/index.html.erb
@@ -99,7 +99,7 @@ excerpt: Use DNSimple API to get your domains and DNS hosting set up and running
   <a href="<%= featured[:main][:url] %>?utm_source=support&utm_medium=web" class="link dim" target="_blank">
     <div class="flex flex-wrap justify-between items-top">
       <div class="w-100 w-50-ns">
-        <img src="<%= featured[:main][:illustration] %>" alt="<%= featured[:main][:title] %>" class="br3" />
+        <img src="<%= featured[:main][:illustration] %>" alt="<%= featured[:main][:title] %>" class="br3">
       </div>
       <div class="w-100 w-50-ns pa3-ns">
         <h3><%= featured[:main][:title] %></h3>
@@ -123,15 +123,10 @@ excerpt: Use DNSimple API to get your domains and DNS hosting set up and running
   <p class="f3 measure">"We now spend <strong>a lot less time managing over 1,500 domains</strong> than we previously spent managing only 200."</p>
   <div class="flex flex-wrap justify-between items-center">
     <div>
-      <img src="/assets/images/go.svg" class="linux-foundation-logo v-mid" style="width: 150px" />
+      <img src="/assets/images/go.svg" class="linux-foundation-logo v-mid" style="width: 150px;">
     </div>
     <div class="pt3 pt0-ns">
-      <a
-        href="https://dnsimple.com/customers/linux-foundation?utm_source=developer&utm_medium=web&utm_content=cta-case-studies"
-        target="_blank"
-        class="button link dim pv3 ph4 br3"
-        >Read case study</a
-      >
+      <a href="https://dnsimple.com/customers/linux-foundation?utm_source=developer&utm_medium=web&utm_content=cta-case-studies" target="_blank" class="button link dim pv3 ph4 br3">Read case study</a>
     </div>
   </div>
 </div>

--- a/content/index.html.erb
+++ b/content/index.html.erb
@@ -96,29 +96,26 @@ excerpt: Use DNSimple API to get your domains and DNS hosting set up and running
 <div class="pv4">
   <h2 class="ma0 pb2 mb2 bb bw1 divider">New Features</h2>
 
-  <a href="<%= featured.first[:url] %>?utm_source=support&utm_medium=web" class="link dim" target="_blank">
+  <a href="<%= featured[:main][:url] %>?utm_source=support&utm_medium=web" class="link dim" target="_blank">
     <div class="flex flex-wrap justify-between items-top">
       <div class="w-100 w-50-ns">
-        <img src="<%= featured.first[:illustration] %>" alt="<%= featured.first[:title] %>" class="br3" />
+        <img src="<%= featured[:main][:illustration] %>" alt="<%= featured[:main][:title] %>" class="br3" />
       </div>
       <div class="w-100 w-50-ns pa3-ns">
-        <h3><%= featured.first[:title] %></h3>
-        <p><%= featured.first[:summary] %></p>
+        <h3><%= featured[:main][:title] %></h3>
+        <p><%= featured[:main][:summary] %></p>
       </div>
     </div>
   </a>
 
   <div class="flex flex-wrap justify-between pv3 bb bt bw1 divider">
-    <div class="w-100 w-50-ns pr3-ns">
-      <a href="<%= featured[1][:url] %>?utm_source=support&utm_medium=web&utm_content=new-features" class="link dim" target="_blank">
-        <h3><%= featured[1][:title] %></h3>
-      </a>
-    </div>
-    <div class="w-100 w-50-ns pr3-ns">
-      <a href="<%= featured[2][:url] %>?utm_source=support&utm_medium=web&utm_content=new-features" class="link dim" target="_blank">
-        <h3><%= featured[2][:title] %></h3>
-      </a>
-    </div>
+    <% featured[:secondary].each do |article| %>
+      <div class="w-100 w-50-ns pr3-ns">
+        <a href="<%= article[:url] %>?utm_source=support&utm_medium=web&utm_content=new-features" class="link dim" target="_blank">
+          <h3><%= article[:title] %></h3>
+        </a>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/content/index.html.erb
+++ b/content/index.html.erb
@@ -9,55 +9,55 @@ excerpt: Use DNSimple API to get your domains and DNS hosting set up and running
 <div class="pv4 flex flex-wrap justify-center justify-start-ns">
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/ruby?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/ruby.svg">
+      <img class="h2 w3" src="/assets/images/ruby.svg" />
       <p>Ruby</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/go?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/go.svg">
+      <img class="h2 w3" src="/assets/images/go.svg" />
       <p>Go</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/elixir?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/elixir.svg">
+      <img class="h2 w3" src="/assets/images/elixir.svg" />
       <p>Elixir</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/node?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/node.svg">
+      <img class="h2 w3" src="/assets/images/node.svg" />
       <p>Node.js</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/csharp?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/dotnet.svg">
+      <img class="h2 w3" src="/assets/images/dotnet.svg" />
       <p>.NET</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/java?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/java.svg">
+      <img class="h2 w3" src="/assets/images/java.svg" />
       <p>Java</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/php?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/php.svg">
+      <img class="h2 w3" src="/assets/images/php.svg" />
       <p>PHP</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/python?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/python.svg">
+      <img class="h2 w3" src="/assets/images/python.svg" />
       <p>Python</p>
     </a>
   </div>
   <div class="text-centered">
     <a class="tc link dim" href="https://dnsimple.com/api/rust?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/rust.svg">
+      <img class="h2 w3" src="/assets/images/rust.svg" />
       <p>Rust</p>
     </a>
   </div>
@@ -91,28 +91,32 @@ excerpt: Use DNSimple API to get your domains and DNS hosting set up and running
   </div>
 </div>
 
+<% featured = blog_articles %>
+
 <div class="pv4">
   <h2 class="ma0 pb2 mb2 bb bw1 divider">New Features</h2>
-  <a href="https://blog.dnsimple.com/2023/12/introducing-domain-control-plane/?utm_source=support&utm_medium=web&utm_content=dcp" class="link dim" target="_blank">
+
+  <a href="<%= featured.first[:url] %>?utm_source=support&utm_medium=web" class="link dim" target="_blank">
     <div class="flex flex-wrap justify-between items-top">
       <div class="w-100 w-50-ns">
-        <img src="/assets/images/features/dcp.png" alt="Domain Control Plane" class="br3">
+        <img src="<%= featured.first[:illustration] %>" alt="<%= featured.first[:title] %>" class="br3" />
       </div>
       <div class="w-100 w-50-ns pa3-ns">
-        <h3>Introducing DNSimple's Domain Control Plane.</h3>
-        <p>Take control of all your domains, DNS, and SSL certificates across registrars and providers &mdash; including those outside DNSimple's infrastructure &mdash; from a single pane of glass.</p>
+        <h3><%= featured.first[:title] %></h3>
+        <p><%= featured.first[:summary] %></p>
       </div>
     </div>
   </a>
+
   <div class="flex flex-wrap justify-between pv3 bb bt bw1 divider">
     <div class="w-100 w-50-ns pr3-ns">
-      <a href="https://blog.dnsimple.com/2023/07/july-feature-focus/?utm_source=support&utm_medium=web&utm_content=new-features" class="link dim" target="_blank">
-        <h3>What's New at DNSimple &mdash; Summer 2023</h3>
+      <a href="<%= featured[1][:url] %>?utm_source=support&utm_medium=web&utm_content=new-features" class="link dim" target="_blank">
+        <h3><%= featured[1][:title] %></h3>
       </a>
     </div>
     <div class="w-100 w-50-ns pr3-ns">
-      <a href="https://blog.dnsimple.com/2023/06/manage-aws-routes-in-dnsimple/?utm_source=support&utm_medium=web&utm_content=new-features" class="link dim" target="_blank">
-        <h3>Manage Your AWS Route 53 DNS from DNSimple</h3>
+      <a href="<%= featured[2][:url] %>?utm_source=support&utm_medium=web&utm_content=new-features" class="link dim" target="_blank">
+        <h3><%= featured[2][:title] %></h3>
       </a>
     </div>
   </div>
@@ -122,11 +126,15 @@ excerpt: Use DNSimple API to get your domains and DNS hosting set up and running
   <p class="f3 measure">"We now spend <strong>a lot less time managing over 1,500 domains</strong> than we previously spent managing only 200."</p>
   <div class="flex flex-wrap justify-between items-center">
     <div>
-      <img src="/assets/images/go.svg" class="linux-foundation-logo v-mid" style="width: 150px;">
+      <img src="/assets/images/go.svg" class="linux-foundation-logo v-mid" style="width: 150px" />
     </div>
     <div class="pt3 pt0-ns">
-      <a href="https://dnsimple.com/customers/linux-foundation?utm_source=developer&utm_medium=web&utm_content=cta-case-studies" target="_blank" class="button link dim pv3 ph4 br3">Read case study</a>
+      <a
+        href="https://dnsimple.com/customers/linux-foundation?utm_source=developer&utm_medium=web&utm_content=cta-case-studies"
+        target="_blank"
+        class="button link dim pv3 ph4 br3"
+        >Read case study</a
+      >
     </div>
   </div>
 </div>
-

--- a/content/index.html.erb
+++ b/content/index.html.erb
@@ -9,55 +9,55 @@ excerpt: Use DNSimple API to get your domains and DNS hosting set up and running
 <div class="pv4 flex flex-wrap justify-center justify-start-ns">
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/ruby?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/ruby.svg" />
+      <img class="h2 w3" src="/assets/images/ruby.svg">
       <p>Ruby</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/go?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/go.svg" />
+      <img class="h2 w3" src="/assets/images/go.svg">
       <p>Go</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/elixir?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/elixir.svg" />
+      <img class="h2 w3" src="/assets/images/elixir.svg">
       <p>Elixir</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/node?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/node.svg" />
+      <img class="h2 w3" src="/assets/images/node.svg">
       <p>Node.js</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/csharp?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/dotnet.svg" />
+      <img class="h2 w3" src="/assets/images/dotnet.svg">
       <p>.NET</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/java?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/java.svg" />
+      <img class="h2 w3" src="/assets/images/java.svg">
       <p>Java</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/php?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/php.svg" />
+      <img class="h2 w3" src="/assets/images/php.svg">
       <p>PHP</p>
     </a>
   </div>
   <div class="text-centered mr3">
     <a class="tc link dim" href="https://dnsimple.com/api/python?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/python.svg" />
+      <img class="h2 w3" src="/assets/images/python.svg">
       <p>Python</p>
     </a>
   </div>
   <div class="text-centered">
     <a class="tc link dim" href="https://dnsimple.com/api/rust?utm_source=developer&utm_medium=web&utm_content=cta-lang" target="_blank">
-      <img class="h2 w3" src="/assets/images/rust.svg" />
+      <img class="h2 w3" src="/assets/images/rust.svg">
       <p>Rust</p>
     </a>
   </div>

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -32,7 +32,7 @@ def blog_articles
   secondary = features.select { |item| item[:title] != main[:title] }
 
   {
-    main:,
+    main: main,
     secondary: secondary.take(2)
   }
 end

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -24,9 +24,15 @@ end
 
 def blog_articles
   uri = URI('https://blog.dnsimple.com/feed.json')
-  # uri = URI('http://localhost:4000/feed.json')
   res = Net::HTTP.get(uri)
   feed = JSON.parse(res, { symbolize_names: true })
+  features = feed[:items].select { |item| item[:tags].downcase.include? "feature" }
 
-  feed[:items].select { |item| item[:tags].downcase.include? "feature" }
+  main = features.find { |item| item[:illustration] }
+  secondary = features.select { |item| item[:title] != main[:title] }
+
+  {
+    main:,
+    secondary: secondary.take(2)
+  }
 end

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -21,3 +21,12 @@ def pretty_print_fixture(filename)
   body = response.read_body
   body ? JSON.pretty_generate(JSON.parse(body)) : nil
 end
+
+def blog_articles
+  uri = URI('https://blog.dnsimple.com/feed.json')
+  # uri = URI('http://localhost:4000/feed.json')
+  res = Net::HTTP.get(uri)
+  feed = JSON.parse(res, { symbolize_names: true })
+
+  feed[:items].select { |item| item[:tags].downcase.include? "feature" }
+end


### PR DESCRIPTION
Dynamically loading "Whats New" features listed on developer site from the blog.

Belongs to: [691](https://github.com/dnsimple/dnsimple-marketing/issues/692)

Loading feed.json from the blog, filtering by "Feature" then displaying the first three posts under the "whats new" section on the homepage.

Previously this was done manually each time we released a new post about a feature. 

QA:
- navigate to site homepage
- inspect whats new section, the anchor links and images should be coming from the blog