### PR TITLE
Add restore price to /domain_prices enpoint

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3695,12 +3695,16 @@ components:
           type: number
           format: float
           description: The domain transfer price represented as a USD amount with dollars and cents.
+        restore_price:
+          type: number
+          format: float
+          description: The domain restore price represented as a USD amount with dollars and cents.
       example:
         domain: ruby.codes
         premium: false
         registration_price: 12.0
         renewal_price: 15.0
-        transfer_price: 15.0
+        restore_price: 25.0
     DomainRegistration:
       type: object
       properties:

--- a/fixtures/v2/api/getDomainPrices/success.http
+++ b/fixtures/v2/api/getDomainPrices/success.http
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"domain":"bingo.pizza","premium":true,"registration_price":20.0,"renewal_price":20.0,"transfer_price":20.0}}
+{"data":{"domain":"bingo.pizza","premium":true,"registration_price":20.0,"renewal_price":20.0,"transfer_price":20.0,"restore_price":20.0}}


### PR DESCRIPTION
https://github.com/dnsimple/dnsimple-business/issues/1655

Adds the `restore_price` to the `GET /:account/registrar/domains/:domain/prices` endpoint

## :mag: QA


## :shipit: Pre/Post tasks


## :shipit: Verification

- [ ] Verify [docs](https://developer.dnsimple.com/v2/registrar/#getDomainPrices)
