### PR TITLE
Add new DNS analytics endpoint to OpenAPI spec 

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3101,7 +3101,6 @@ components:
           - 'zone_name:asc'
           - 'zone_name:desc'
     SortDomains:
-    SortDomains:
       description: Sort results. Default sorting is ascending by name.
       name: sort
       style: form

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2756,8 +2756,10 @@ paths:
                       rows:
                         type: array
                         items:
-                          type:
-                            - string | integer
+                          anyOf:
+                            - type: integer
+                            - type: string
+                            - $ref: '#/components/schemas/Date'
                           example: [example.com,102985]
                       headers:
                         type: array

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2699,7 +2699,9 @@ paths:
       summary: Delete a webhook
   '/{account}/dns_analytics':
     get:
-      description: Retrieve data about DNS queries for the zones in an account.
+      description:
+        Queries and returns DNS Analytics data available for the provided query parameters.
+        This API is currently in Public Beta. During the Public Beta period changes may occur at any time.
       parameters:
         - $ref: '#/components/parameters/Account'
         - startDate:
@@ -2727,8 +2729,9 @@ paths:
         - groupings:
           description:
             How to group the results about the account's DNS analytics.
-            Multiple groupings can be provided separated by commas.
-            If omitted defaults to grouping by volume.
+            No groupings will be applied by default unless specified.
+            Multiple groupings can be provided, separated by a comma.
+            Applying groupings to the query will add columns to the response payload.
           name: groupings
           style: form
           in: query
@@ -2742,7 +2745,6 @@ paths:
         - $ref: '#/components/parameters/SortDNSAnalytics'
         - $ref: '#/components/parameters/PaginationPage'
         - $ref: '#/components/parameters/PaginationPerPage'
-
       operationId: dnsAnalytics
       tags:
         - billing
@@ -3034,7 +3036,7 @@ components:
           - 'email:asc'
           - 'email:desc'
     SortDNSAnalytics:
-      description: Sort results. Default sorting is ascending both by date, and zone name.
+      description: Sort results. Default sorting policy is by ascending date, then ascending zone_name.
       name: sort
       style: form
       in: query

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3091,13 +3091,7 @@ components:
       required: false
       schema:
         type: string
-        enum:
-          - 'date:asc'
-          - 'date:desc'
-          - 'volume:asc'
-          - 'volume:desc'
-          - 'zone_name:asc'
-          - 'zone_name:desc'
+        example: 'volume:desc,zone_name:asc'
     SortDomains:
       description: Sort results. Default sorting is ascending by name.
       name: sort

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2707,7 +2707,7 @@ paths:
         - name: start_date
           description:
             Only include results after the given date. Format is ISO8601 (YYYY-MM-DD).
-            It can be a max. of 31 days away from the end_date.
+            It can be a max of 31 days away from the end_date.
             If omitted, it defaults to 31 days ago.
           style: form
           in: query
@@ -2717,7 +2717,7 @@ paths:
         - name: end_date
           description:
             Only include results before the given date. Format is ISO8601 (YYYY-MM-DD).
-            It can be a max. of 31 days away from the start_date.
+            It can be a max of 31 days away from the start_date.
             If omitted, it defaults to 1 day ago.
           style: form
           in: query
@@ -2785,7 +2785,7 @@ paths:
                         example: "date,zone_name"
                       page:
                         type: integer
-                        description: The returned page numeber.
+                        description: The returned page number.
                         example: 1
                       per_page:
                         type: integer

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -11,12 +11,12 @@ info:
 externalDocs:
   url: 'https://developer.dnsimple.com'
 security:
-  - basicAuth: []
-  - bearerAuth: []
+  - basicAuth: [ ]
+  - bearerAuth: [ ]
 servers:
   - url: 'https://api.dnsimple.com/v2'
     description: DNSimple Production API
-    variables: {}
+    variables: { }
   - url: 'https://api.sandbox.dnsimple.com/v2'
     description: 'DNSimple Sandbox API used for testing'
 tags:
@@ -48,7 +48,7 @@ paths:
   /accounts:
     get:
       description: Lists the accounts the current authenticated entity has access to.
-      parameters: []
+      parameters: [ ]
       operationId: listAccounts
       tags:
         - accounts
@@ -68,7 +68,7 @@ paths:
   /whoami:
     get:
       description: Retrieves the details about the current authenticated entity used to access the API.
-      parameters: []
+      parameters: [ ]
       operationId: whoami
       tags:
         - identity
@@ -740,8 +740,8 @@ paths:
                   type: array
                   items:
                     type: string
-                  default: []
-                  example: ['docs.example.com', 'status.example.com']
+                  default: [ ]
+                  example: [ 'docs.example.com', 'status.example.com' ]
                 signature_algorithm:
                   description: 'Optional string to determine the signature algorithm to be used. Either `ECDSA` or `RSA`'
                   type: string
@@ -2740,22 +2740,9 @@ paths:
               - 'volume'
               - 'zone_name'
         - $ref: '#/components/parameters/SortDNSAnalytics'
-        - page:
-          description: The page of the results requested. Defaults to 1.
-          name: page
-          style: form
-          in: query
-          required: false
-          schema:
-            type: integer
-        - per_page:
-          description: The amount of rows to return in each page. Defaults to 1000.
-          name: per_page
-          style: form
-          in: query
-          required: false
-          schema:
-            type: integer
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/PaginationPerPage'
+
       operationId: dnsAnalytics
       tags:
         - billing
@@ -2986,6 +2973,25 @@ components:
       description: Only include results with a contact_id field exactly matching the given string
       schema:
         type: string
+    PaginationPage:
+      description: The page of the results requested. Defaults to 1.
+      name: page
+      style: form
+      in: query
+      required: false
+      schema:
+        type: integer
+    PaginationPerPage:
+      description:
+        The amount of rows to return in each page.
+        The default is usually 100. 
+        There are endpoints that override this default to accommodate specific use cases.
+      name: per_page
+      style: form
+      in: query
+      required: false
+      schema:
+        type: integer
     SortCertificates:
       description: Sort results. Default sorting is by id.
       name: sort
@@ -4674,7 +4680,7 @@ components:
         name: 'Primary Server'
         ip: '1.1.1.1'
         port: 4567
-        linked_secondary_zones: ['example.com']
+        linked_secondary_zones: [ 'example.com' ]
         created_at: '2016-08-11T10:16:03Z'
         updated_at: '2016-08-11T10:16:03Z'
     Push:
@@ -4737,7 +4743,7 @@ components:
         contact_id: 2
         domain_id: 2
         state: completed
-        extended_attributes: { "x-fi-registrant-idnumber":"1234" }
+        extended_attributes: { "x-fi-registrant-idnumber": "1234" }
         registry_owner_change: false
         irt_lock_lifted_by: '2013-12-08'
         created_at: '2013-11-08T17:23:15Z'
@@ -4758,7 +4764,7 @@ components:
       example:
         contact_id: 2
         domain_id: 2
-        extended_attributes: [{ "name":"x-fi-registrant-birth-date" ,"title":"The registrant's birth date", "description":"Format is: YYYY-MM-DD.","required":false,"options":[] }]
+        extended_attributes: [ { "name": "x-fi-registrant-birth-date" ,"title": "The registrant's birth date", "description": "Format is: YYYY-MM-DD.","required": false,"options": [ ] } ]
         registry_owner_change: false
     SecondaryDNS:
       type: object
@@ -5903,7 +5909,7 @@ components:
             example:
               domain_id: "example.com"
               contact_id: "2"
-              extended_attributes: { "x-fi-registrant-idnumber":"1234" }
+              extended_attributes: { "x-fi-registrant-idnumber": "1234" }
     RegistrantChangeCheck:
       description: Contact change attributes
       required: true

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2760,7 +2760,7 @@ paths:
                             - type: integer
                             - type: string
                             - $ref: '#/components/schemas/Date'
-                          example: [example.com,102985]
+                          example: ["example.com", "2024-08-01", 102985]
                       headers:
                         type: array
                         items:

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -273,24 +273,6 @@ paths:
         '404':
           $ref: '#/components/responses/404'
       summary: Add a collaborator
-  '/{account}/domains/{domain}/collaborators/{collaborator}':
-    delete:
-      description: Removes a collaborator from the domain.
-      parameters:
-        - $ref: '#/components/parameters/Account'
-        - $ref: '#/components/parameters/Domain'
-        - $ref: '#/components/parameters/Collaborator'
-      operationId: removeDomainCollaborator
-      tags:
-        - domain collaborators
-      responses:
-        '204':
-          description: Successfully removed collaborator
-        '400':
-          $ref: '#/components/responses/400'
-        '404':
-          $ref: '#/components/responses/404'
-      summary: Remove a collaborator
   '/{account}/domains/{domain}/dnssec':
     get:
       description: Gets the DNSSEC status for an existing domain.
@@ -1601,7 +1583,6 @@ paths:
         '404':
           $ref: '#/components/responses/404'
       summary: Delete a primary server
-
   '/{account}/secondary_dns/primaries/{primaryserver}/link':
     put:
       description: Link the primary server to a secondary zone.
@@ -1651,6 +1632,7 @@ paths:
         '404':
           $ref: '#/components/responses/404'
       summary: Unlink a primary server from a secondary zone
+
   '/{account}/secondary_dns/zones':
     post:
       summary: Create a secondary zone
@@ -2168,6 +2150,24 @@ paths:
         '400':
           $ref: '#/components/responses/400'
       summary: Start registrant chnange
+  '/{account}/domains/{domain}/collaborators/{collaborator}':
+    delete:
+      description: Removes a collaborator from the domain.
+      parameters:
+        - $ref: '#/components/parameters/Account'
+        - $ref: '#/components/parameters/Domain'
+        - $ref: '#/components/parameters/Collaborator'
+      operationId: removeDomainCollaborator
+      tags:
+        - domain collaborators
+      responses:
+        '204':
+          description: Successfully removed collaborator
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      summary: Remove a collaborator
   '/{account}/registrar/registrant_changes/check':
     post:
       description: Retrieves the requirements of a registrant change.
@@ -2697,6 +2697,70 @@ paths:
         '204':
           description: Successfully deleted a webhook.
       summary: Delete a webhook
+  '/{account}/dns_analytics':
+    get:
+      description: Retrieve data about DNS queries for the zones in an account.
+      parameters:
+        - $ref: '#/components/parameters/Account'
+        - startDate:
+          description:
+            Only include results after the given date. Format is ISO8601 (YYYY-MM-DD).
+            It can be at most 31 days away from the end_date.
+            If omitted it defaults to 31 days ago.
+          name: start_date
+          style: form
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/Date'
+        - endDate:
+          description:
+            Only include results before the given date. Format is ISO8601 (YYYY-MM-DD).
+            It can be at most 31 days away from the start_date.
+            If omitted it defaults to 1 day ago.
+          name: end_date
+          style: form
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/Date'
+        - groupings:
+          description:
+            How to group the results about the account's DNS analytics.
+            Multiple groupings can be provided separated by commas.
+            If omitted defaults to grouping by volume.
+          name: groupings
+          style: form
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - 'date'
+              - 'volume'
+              - 'zone_name'
+        - $ref: '#/components/parameters/SortDNSAnalytics'
+        - page:
+          description: The page of the results requested. Defaults to 1.
+          name: page
+          style: form
+          in: query
+          required: false
+          schema:
+            type: integer
+        - per_page:
+          description: The amount of rows to return in each page. Defaults to 1000.
+          name: per_page
+          style: form
+          in: query
+          required: false
+          schema:
+            type: integer
+      operationId: dnsAnalytics
+      tags:
+        - billing
+        - zones
+      summary: Analytics about DNS queries
 components:
   securitySchemes:
     basicAuth:
@@ -2963,6 +3027,22 @@ components:
           - 'label:desc'
           - 'email:asc'
           - 'email:desc'
+    SortDNSAnalytics:
+      description: Sort results. Default sorting is ascending both by date, and zone name.
+      name: sort
+      style: form
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - 'date:asc'
+          - 'date:desc'
+          - 'volume:asc'
+          - 'volume:desc'
+          - 'zone_name:asc'
+          - 'zone_name:desc'
+    SortDomains:
     SortDomains:
       description: Sort results. Default sorting is ascending by name.
       name: sort

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2149,7 +2149,7 @@ paths:
                     $ref: '#/components/schemas/RegistrantChange'
         '400':
           $ref: '#/components/responses/400'
-      summary: Start registrant chnange
+      summary: Start registrant change
   '/{account}/domains/{domain}/collaborators/{collaborator}':
     delete:
       description: Removes a collaborator from the domain.
@@ -2701,14 +2701,14 @@ paths:
     get:
       description:
         Queries and returns DNS Analytics data available for the provided query parameters.
-        This API is currently in Public Beta. During the Public Beta period changes may occur at any time.
+        This API is currently in Public Beta. During the Public Beta period, changes may occur at any time.
       parameters:
         - $ref: '#/components/parameters/Account'
         - name: start_date
           description:
             Only include results after the given date. Format is ISO8601 (YYYY-MM-DD).
-            It can be at most 31 days away from the end_date.
-            If omitted it defaults to 31 days ago.
+            It can be a max. of 31 days away from the end_date.
+            If omitted, it defaults to 31 days ago.
           style: form
           in: query
           required: false
@@ -2717,8 +2717,8 @@ paths:
         - name: end_date
           description:
             Only include results before the given date. Format is ISO8601 (YYYY-MM-DD).
-            It can be at most 31 days away from the start_date.
-            If omitted it defaults to 1 day ago.
+            It can be a max. of 31 days away from the start_date.
+            If omitted, it defaults to 1 day ago.
           style: form
           in: query
           required: false
@@ -2726,7 +2726,7 @@ paths:
             $ref: '#/components/schemas/Date'
         - name: groupings
           description:
-            How to group the results about the account's DNS analytics.
+            How to group the results of the account's DNS analytics.
             No groupings will be applied by default unless specified.
             Multiple groupings can be provided, separated by a comma.
             Applying groupings to the query will add columns to the response payload.

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2704,35 +2704,32 @@ paths:
         This API is currently in Public Beta. During the Public Beta period changes may occur at any time.
       parameters:
         - $ref: '#/components/parameters/Account'
-        - startDate:
+        - name: start_date
           description:
             Only include results after the given date. Format is ISO8601 (YYYY-MM-DD).
             It can be at most 31 days away from the end_date.
             If omitted it defaults to 31 days ago.
-          name: start_date
           style: form
           in: query
           required: false
           schema:
             $ref: '#/components/schemas/Date'
-        - endDate:
+        - name: end_date
           description:
             Only include results before the given date. Format is ISO8601 (YYYY-MM-DD).
             It can be at most 31 days away from the start_date.
             If omitted it defaults to 1 day ago.
-          name: end_date
           style: form
           in: query
           required: false
           schema:
             $ref: '#/components/schemas/Date'
-        - groupings:
+        - name: groupings
           description:
             How to group the results about the account's DNS analytics.
             No groupings will be applied by default unless specified.
             Multiple groupings can be provided, separated by a comma.
             Applying groupings to the query will add columns to the response payload.
-          name: groupings
           style: form
           in: query
           required: false
@@ -2760,8 +2757,7 @@ paths:
                         type: array
                         items:
                           type:
-                            - string
-                            - integer
+                            - string | integer
                           example: [example.com,102985]
                       headers:
                         type: array

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2745,6 +2745,56 @@ paths:
         - $ref: '#/components/parameters/SortDNSAnalytics'
         - $ref: '#/components/parameters/PaginationPage'
         - $ref: '#/components/parameters/PaginationPerPage'
+      responses:
+        '200':
+          description: Successfully retrieved DNS analytics data.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      rows:
+                        type: array
+                        items:
+                          type:
+                            - string
+                            - integer
+                          example: [example.com,102985]
+                      headers:
+                        type: array
+                        items:
+                          type: string
+                          example: zone_name,volume
+                  query:
+                    type: object
+                    properties:
+                      account_id:
+                        type: integer
+                      start_date:
+                        $ref: '#/components/schemas/Date'
+                      end_date:
+                        $ref: '#/components/schemas/Date'
+                      sort:
+                        type: string
+                        description: Sorting applied to the returned data.
+                        example: "date:asc,zone_name:asc"
+                      groupings:
+                        type: string
+                        description: Grouping applied to the returned data.
+                        example: "date,zone_name"
+                      page:
+                        type: integer
+                        description: The returned page numeber.
+                        example: 1
+                      per_page:
+                        type: integer
+                        description: The page size used to generate the data.
+                        example: 1000
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
       operationId: dnsAnalytics
       tags:
         - billing

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2765,7 +2765,7 @@ paths:
                         type: array
                         items:
                           type: string
-                          example: zone_name,volume
+                          example: "zone_name,volume"
                   query:
                     type: object
                     properties:


### PR DESCRIPTION
Closes dnsimple/dnsimple-app#25676

This PR:
- Updates the OpenAPI spec with the new endpoint.

> [!NOTE]  
> This is my first time updating the OpenAPI spec so expect rough edges.
> 
> Note that I chose not to extract much to be referenced and write the spec pretty much in line: I do not think much of what we have in this endpoint is currently reusable.