### PR TITLE
Add dependabot instructions to update JS files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,29 @@ updates:
       - task
       - dependencies
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
       time: '12:00'
     open-pull-requests-limit: 10
     labels:
       - task
       - dependencies
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+      time: '16:00'
+    open-pull-requests-limit: 10
+    labels:
+      - task
+      - dependencies
+    groups:
+      javascript-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
This config was missing, and we never updated JS dependencies. As a result, when we had a vulnerability alert recently, we dependabot was unable to open a PR to fix it.

Similar to https://github.com/dnsimple/dnsimple-support/pull/1133
