### PR TITLE
Removes Google Universal Analytics

### DIFF
--- a/layouts/analytics.html
+++ b/layouts/analytics.html
@@ -1,11 +1,10 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=<%= @config[:google_universal_analytics_id] %>"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= @config[:google_analytics_4_id] %>"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '<%= @config[:google_universal_analytics_id] %>');
   gtag('config', '<%= @config[:google_analytics_4_id] %>');
 </script>
 

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -81,7 +81,6 @@ watcher:
 
 base_url: https://developer.dnsimple.com
 
-google_universal_analytics_id: "UA-17301867-4"
 google_analytics_4_id: "G-ZNH6WB6RFQ"
 
 environments:


### PR DESCRIPTION
This PR removes Google Universal Analytics in favor of Google Analytics 4.

I've verified that we're using the latest `gtag.js` code and that we can pass the GA4 variable to it.