### PR TITLE
fix: missing transfer lock entry in menu

### DIFF
--- a/layouts/sidebar.html
+++ b/layouts/sidebar.html
@@ -25,8 +25,9 @@
   <li><a href="/v2/tlds/">TLDs</a></li>
   <li><a href="/v2/registrar/">Registration</a></li>
   <li><ul class="nav-list">
-    <li><a href="/v2/registrar/delegation/">Delegation</a></li>
     <li><a href="/v2/registrar/auto-renewal/">Auto Renewal</a></li>
+    <li><a href="/v2/registrar/delegation/">Delegation</a></li>
+    <li><a href="/v2/registrar/transfer-lock/">Transfer Lock</a></li>
     <li><a href="/v2/registrar/whois-privacy/">Whois Privacy</a></li>
   </ul></li>
   <li><a href="/v2/zones/">DNS Zones</a></li>


### PR DESCRIPTION
This PR adds the missing sidebar menu entry for the Transfer Lock API.