### PR TITLE
Fixing broken links on the developer site

### DIFF
--- a/content/libraries.markdown
+++ b/content/libraries.markdown
@@ -27,7 +27,7 @@ _Please keep in mind that some of these libraries may be incomplete or outdated.
 
 ### Ruby
 
-- [fog-dnsimple](https://github.com/fog/fog-dnsimple) - The [fog](http://fog.io/) module for DNSimple.
+- [fog-dnsimple](https://github.com/fog/fog-dnsimple) - The [fog](https://fog.github.io/) module for DNSimple.
 
 ### Python
 

--- a/content/tools.markdown
+++ b/content/tools.markdown
@@ -45,7 +45,7 @@ Manage zones for on-premise and self-hosted CoreDNS instances with DNSimple.
 <small>
 [documentation](https://support.dnsimple.com/articles/integrated-dns-provider-coredns/) &bull;
 [source code](https://github.com/dnsimple/coredns-dnsimple) &bull;
-[announcement](https://blog.dnsimple.com/2023/07/coredns-integrated-provider/)
+[announcement](https://blog.dnsimple.com/2023/08/coredns-integrated-provider/)
 </small>
 
 


### PR DESCRIPTION
belongs to https://github.com/dnsimple/dnsimple-marketing/issues/810

fixing broken links found in a scan