### PR TITLE
Expand `search.json` to include more searchable fields

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -6,15 +6,28 @@ module Search
   include Nanoc::Helpers::Text
 
   def create_search_index
-    index = []
-    @items.each do |item|
-      if item.attributes[:filename].end_with?('markdown')
-        index << { id: item.path, title: item.attributes[:title], body: strip_html(item.compiled_content) }
-      end
-    end
-
     index_file = File.join(@config[:output_dir], 'search.json')
-    File.write(index_file, JSON.generate(index))
+    File.write(index_file, articles_json)
+  end
+
+  def articles_json
+    @articles_json ||= begin
+      index = []
+
+      @items.each do |item|
+        next unless item.attributes[:filename].end_with?('markdown')
+
+        index << {
+          id: item.path,
+          title: item.attributes[:title],
+          excerpt: item[:excerpt],
+          categories: item[:categories],
+          body: item.compiled_content
+        }
+      end
+
+      JSON.generate(index)
+    end
   end
 end
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,11 @@
   command = "NANOC_ENV=production rake publish"
 
 [[headers]]
+  for = "/search.json"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+
+[[headers]]
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,6 @@ function toggleColorMode (e) {
 };
 
 const toggleColorButtons = document.querySelectorAll(".color-mode__btn");
-console.log(toggleColorButtons);
 
 toggleColorButtons.forEach(btn => {
   btn.addEventListener("click", toggleColorMode);


### PR DESCRIPTION
This PR adds a few more fields to `/search.json`. It brings it to parity with the support site.

## QA

Ensure the search works @ https://deploy-preview-760--dnsimple-developer.netlify.app/