### PR TITLE
Fix alert icons

### DIFF
--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -54,26 +54,38 @@
 }
 
 .marker-info {
+  box-shadow: -6px 0 0 0 var(--blue);
+
   &:before {
-    @include font-awesome("\f129");
+    @include font-awesome("\f05a");
+    color: var(--blue);
   }
 }
 
 .marker-tip {
+  box-shadow: -6px 0 0 0 var(--green);
+
   &:before {
-    @include font-awesome("\f075");
+    @include font-awesome("\f0eb");
+    color: var(--green);
   }
 }
 
 .marker-note {
+  box-shadow: -6px 0 0 0 var(--yellow);
+
   &:before {
-    @include font-awesome("\f303");
+    @include font-awesome("\f249");
+    color: var(--yellow);
   }
 }
 
 .marker-warning {
+  box-shadow: -6px 0 0 0 var(--orange);
+
   &:before {
     @include font-awesome("\f071");
+    color: var(--orange);
   }
 }
 

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -47,9 +47,10 @@
   &:before {
     display: block;
     float: left;
-    margin-left: -25px;
-    font-size: 16px;
-    line-height: 140%;
+    margin-left: -30px;
+    font-size: 1.4rem;
+    line-height: 100%;
+    color: var(--element2);
   }
 }
 

--- a/content/assets/css/_colorscheme.scss
+++ b/content/assets/css/_colorscheme.scss
@@ -26,6 +26,7 @@
   --green:  hsl(100, 100%, 30%);;
   --gray:  hsl(50, 0%, 50%);;
   --orange:  hsl(30, 100%, 50%);;
+  --yellow: hsl(47, 100%, 47%);
   --icon-color: hsl(0deg 0% 70%);
 }
 
@@ -47,6 +48,7 @@
   --green:  hsl(100, 100%, 40%);;
   --gray:  hsl(50, 0%, 70%);;
   --orange:  hsl(30, 100%, 60%);;
+  --yellow: hsl(57, 100%, 50%);
   --icon-color: hsl(248deg 31% 40%);
 }
 


### PR DESCRIPTION
This PR updates various alert icons to ensure they align correctly with the corresponding semantic tags and matches what we're using in the support site. See https://github.com/dnsimple/dnsimple-support/pull/1452

## Info
<img width="719" alt="Screenshot 2025-04-15 at 18 02 35" src="https://github.com/user-attachments/assets/ce2188b1-3305-4ab7-a28b-d661adcebefe" />
<img width="722" alt="Screenshot 2025-04-15 at 18 02 58" src="https://github.com/user-attachments/assets/8dde86b0-cedb-4510-ae3a-888d46709ac0" />

## Note
<img width="717" alt="Screenshot 2025-04-15 at 18 03 20" src="https://github.com/user-attachments/assets/8a0b0d42-26fd-4f5e-acdd-1744d4f9e86b" />

<img width="725" alt="Screenshot 2025-04-15 at 18 03 33" src="https://github.com/user-attachments/assets/6d664b25-5f76-42cc-8217-76a9be205241" />

## Tip
<img width="717" alt="Screenshot 2025-04-15 at 18 04 14" src="https://github.com/user-attachments/assets/0ee516df-3ce6-457a-b2b9-357d85fac39a" />
<img width="718" alt="Screenshot 2025-04-15 at 18 04 32" src="https://github.com/user-attachments/assets/aa9cb0fc-0dee-49f8-8157-ac7a6bf27d53" />

## Warning
<img width="714" alt="Screenshot 2025-04-15 at 18 05 30" src="https://github.com/user-attachments/assets/7afef1f8-3afa-4949-8b92-d23a7a34fc48" />
<img width="721" alt="Screenshot 2025-04-15 at 18 05 49" src="https://github.com/user-attachments/assets/fc986ca8-1df7-4185-bb1d-ea5a1c7773c8" />
