### PR TITLE
docs: Clarify sandbox behavior for DNS and domains

### DIFF
--- a/content/sandbox.markdown
+++ b/content/sandbox.markdown
@@ -36,13 +36,16 @@ The API hostname is `api.sandbox.dnsimple.com`. This hostname follows the same [
 This site is generally an exact duplicate of the production application, but there are some exceptions. Instead of actually performing domain registration, charging credit cards, etc. it _mocks_ these functions.
 
 
+## Testing Zones and DNS
+
+In the Sandbox environment, you can add as many DNS zones and DNS records as you would in the production environment. This is useful for testing your API integrations, record formats, and automation workflows.
+
+However, please note that there is no public authoritative name server in the Sandbox. As a result, any zones or records you create will not publicly resolve.
+
+
 ## Testing Domains
 
 To register domains with your sandbox account you will need an active subscription ([see below](#testing-subscriptions)). You can register every domain you want, as long as it's available because you are still sharing a system with other customers.
-
-<note>
-Domains you register within the sandbox will not have any DNS service.
-</note>
 
 
 ## Testing Certificates

--- a/content/sandbox.markdown
+++ b/content/sandbox.markdown
@@ -47,6 +47,9 @@ However, please note that there is no public authoritative name server in the Sa
 
 To register domains with your sandbox account you will need an active subscription ([see below](#testing-subscriptions)). You can register every domain you want, as long as it's available because you are still sharing a system with other customers.
 
+<note>
+Domain registration and all other domain-related actions in the Sandbox are performed against the registry OT&E (Operational Test and Evaluation) environments, not the live production registries. This means that the domains you see or register in the Sandbox do not reflect the real-world status of domain registrations. You can test availability checks, registrations, transfers, and other domain operations as you would in production, but please do not assume that a domain registered in the real world is registered in Sandbox, or vice-versa.
+</note>
 
 ## Testing Certificates
 


### PR DESCRIPTION
This PR expands the sandbox article with two common information:

- Sandbox DNS zones and records don't resolve
- Sandbox domain registration relies on registry OT&E, and therefore the domain name availability is not the same of the real world
