### PR TITLE
openapi: Document ZoneRecord attributes

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -5523,7 +5523,6 @@ components:
           default: 0
         type:
           $ref: '#/components/schemas/ZoneRecordType'
-          description: The type of DNS record (e.g., A, AAAA, CNAME, MX, TXT).
         regions:
           type: array
           description: The regions where this record is active. If empty, the record is active in all regions.
@@ -5550,7 +5549,7 @@ components:
         - FRA
     ZoneRecordType:
       type: string
-      description: Supported DNS record types at DNSimple. Note that some record types may only be available on specific plans.
+      description: The type of DNS record. Supported DNS record types are listed below. Note that some record types may only be available on specific plans.
       enum:
         - A
         - AAAA


### PR DESCRIPTION
This PR adds a documentation to all properties of ZoneRecord:

- [In the documentation](https://developer.dnsimple.com/v2/zones/records/#zone-record-attributes) we refer to the OpenAPI file, yet almost no schema node has property description
- Adding description clarifies the intent of some less-than-common attributes like Priority, or what is the expected value of attributes like TTL
- It help building documentation

<img width="895" alt="Screenshot 2025-06-03 at 14 17 30" src="https://github.com/user-attachments/assets/f34b2ee1-1334-4ce0-838b-9f877ad4a084" />

I also fixed validation issues where we added descriptions along with `$ref`. I will continue in a follow up PR by rolling out the update to all CreatedAt and UpdatedAt fields.