### PR TITLE
Update openapi `required` values - Part 5

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2342,6 +2342,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/Service'

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1812,6 +1812,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/ZoneDistribution'
@@ -3373,6 +3374,7 @@ components:
       description: 'A nullable date-time value. The value can be null, when present the value is formatted according to the ISO 8601 specification.'
     Error:
       type: object
+      required: [message]
       properties:
         message:
           type: string
@@ -6074,6 +6076,7 @@ components:
     ZoneDistribution:
       type: object
       description: Zone distribution check
+      required: [distributed]
       properties:
         distributed:
           type: boolean

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1990,6 +1990,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/ZoneDistribution'

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1789,6 +1789,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/ZoneFile'
@@ -6057,6 +6058,7 @@ components:
     ZoneFile:
       type: object
       description: A DNS zone file.
+      required: [zone]
       properties:
         zone:
           type: string

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1741,6 +1741,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data, pagination]
                 properties:
                   data:
                     type: array
@@ -6006,6 +6007,16 @@ components:
     Zone:
       type: object
       description: Represents a DNS zone.
+      required:
+        - id
+        - account_id
+        - name
+        - reverse
+        - secondary
+        - last_transferred_at
+        - active
+        - created_at
+        - updated_at
       properties:
         id:
           type: integer
@@ -6021,6 +6032,7 @@ components:
           description: 'Returns true for a secondary zone, false for a primary zone.'
         last_transferred_at:
           type: string
+          nullable: true
           format: date-time
           example: '2010-01-01T01:00:00Z'
           description: Returns the date the zone was last transferred. Used if it is a secondary zone.

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1872,6 +1872,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data, pagination]
                 properties:
                   data:
                     type: array
@@ -1897,6 +1898,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/ZoneRecord'
@@ -6827,6 +6829,10 @@ components:
         application/json:
           schema:
             type: object
+            required:
+              - name
+              - type
+              - content
             properties:
               name:
                 type: string

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2318,6 +2318,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data, pagination]
                 properties:
                   data:
                     type: array
@@ -5349,6 +5350,17 @@ components:
           $ref: '#/components/schemas/DateTimeUpdatedAt'
     Service:
       type: object
+      required:
+        - id
+        - name
+        - sid
+        - description
+        - setup_description
+        - requires_setup
+        - default_subdomain
+        - created_at
+        - updated_at
+        - settings
       example:
         id: 2
         name: Service 2
@@ -5400,6 +5412,13 @@ components:
             $ref: '#/components/schemas/ServiceSetting'
     ServiceSetting:
       type: object
+      required:
+        - name
+        - label
+        - append
+        - description
+        - example
+        - password
       properties:
         name:
           type: string
@@ -5409,6 +5428,7 @@ components:
           description: The human-readable label value
         append:
           type: string
+          nullable: true
           description: Additional text to append to the input field
         description:
           type: string

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1843,6 +1843,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     type: array
@@ -6086,6 +6087,19 @@ components:
     ZoneRecord:
       type: object
       description: A single DNS record in a zone.
+      required:
+        - id
+        - zone_id
+        - parent_id
+        - name
+        - content
+        - ttl
+        - priority
+        - type
+        - regions
+        - system_record
+        - created_at
+        - updated_at
       example:
         id: 1
         zone_id: example.com
@@ -6471,24 +6485,45 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              ns_names:
-                type: array
-                items:
-                  type: string
-                example:
-                  - ns1.dnsimple.com
-                  - ns2.dnsimple.com
-                  - ns3.dnsimple.com
-                  - ns4.dnsimple.com
-              ns_set_ids:
-                type: array
-                items:
-                  type: integer
-                example:
-                  - 1
-                  - 2
+            anyOf:
+              - type: object
+                required: [ns_names]
+                properties:
+                  ns_names:
+                    type: array
+                    items:
+                      type: string
+                    example:
+                      - ns1.dnsimple.com
+                      - ns2.dnsimple.com
+                      - ns3.dnsimple.com
+                      - ns4.dnsimple.com
+                  ns_set_ids:
+                    type: array
+                    items:
+                      type: integer
+                    example:
+                      - 1
+                      - 2
+              - type: object
+                required: [ns_set_ids]
+                properties:
+                  ns_names:
+                    type: array
+                    items:
+                      type: string
+                    example:
+                      - ns1.dnsimple.com
+                      - ns2.dnsimple.com
+                      - ns3.dnsimple.com
+                      - ns4.dnsimple.com
+                  ns_set_ids:
+                    type: array
+                    items:
+                      type: integer
+                    example:
+                      - 1
+                      - 2
     DomainRegister:
       description: Domain registration attributes
       required: true

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -2023,6 +2023,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/Zone'
@@ -2048,6 +2049,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/Zone'

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1766,6 +1766,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/Zone'

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1924,6 +1924,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/ZoneRecord'
@@ -1948,6 +1949,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [data]
                 properties:
                   data:
                     $ref: '#/components/schemas/ZoneRecord'
@@ -1965,8 +1967,6 @@ paths:
       operationId: deleteZoneRecord
       tags:
         - zones
-      requestBody:
-        $ref: '#/components/requestBodies/ZoneRecordDelete'
       responses:
         '204':
           description: Successfully deleted zone record.
@@ -6897,25 +6897,6 @@ components:
               priority: 20
               regions:
                 - global
-    ZoneRecordDelete:
-      description: Zone record delete attributes
-      required: false
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              integrated_zones:
-                type: array
-                items:
-                  type: integer
-                example:
-                  - 1
-                  - 2
-            example:
-              integrated_zones:
-                - 1
-                - 2
   headers:
     X-RateLimit-Limit:
       description: The maximum number of requests you can perform per hour.

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -6220,6 +6220,9 @@ components:
         application/json:
           schema:
             type: object
+            required:
+              - message
+              - errors
             properties:
               message:
                 type: string
@@ -6277,6 +6280,7 @@ components:
         application/json:
           schema:
             type: object
+            required: [message]
             properties:
               message:
                 type: string
@@ -6290,6 +6294,7 @@ components:
         application/json:
           schema:
             type: object
+            required: [message]
             properties:
               message:
                 type: string
@@ -6303,6 +6308,7 @@ components:
         application/json:
           schema:
             type: object
+            required: [message]
             properties:
               message:
                 type: string
@@ -6325,6 +6331,7 @@ components:
         application/json:
           schema:
             type: object
+            required: [message]
             properties:
               message:
                 type: string

--- a/content/v2/zones/records.markdown
+++ b/content/v2/zones/records.markdown
@@ -299,22 +299,6 @@ curl  -H 'Authorization: Bearer <token>' \
       https://api.dnsimple.com/v2/1010/zones/example.com/records/5
 ~~~
 
-### Input
-
-The following fields are updateable. You can pass zero or any of them.
-
-Name | Type | Description
------|------|------------
-`integrated_zones` | `array` | Optional set of IDs identifying the zones where the record should be deleted. If not specified, the record deletion will be applied to the DNSimple zone and all integrated zones that support the record type. If specified, "dnsimple" must be included to delete the record from the DNSimple zone.
-
-##### Example
-
-~~~json
-{
-  "integrated_zones": [1, 2, "dnsimple"]
-}
-~~~
-
 ### Response
 
 Responds with HTTP 204 on success.


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-developer/issues/794

Updates the OpenAPI `required` specs of the following endpoints:

- GET /{account}/zones
- GET /{account}/zones/{zone}
- GET /{account}/zones/{zone}/file
- GET /{account}/zones/{zone}/distribution
- PUT /{account}/zones/{zone}/ns_records
- GET /{account}/zones/{zone}/records
- POST /{account}/zones/{zone}/records
- GET /{account}/zones/{zone}/records/{zonerecord}
- PATCH /{account}/zones/{zone}/records/{zonerecord}
- DELETE /{account}/zones/{zone}/records/{zonerecord}
- GET /{account}/zones/{zone}/records/{zonerecord}/distribution
- PUT /{account}/zones/{zone}/activation
- DELETE /{account}/zones/{zone}/activation
- GET /services
- GET /services/{service}
- GET /{account}/domains/{domain}/services
- POST /{account}/domains/{domain}/services/{service}
- DELETE /{account}/domains/{domain}/services/{service}
- 4XX error responses

Also removes `integrated_zones` from DELETE /{account}/zones/{zone}/records/{zonerecord} as OpenAPI does not officially support requestBody for DELETE (part of https://github.com/dnsimple/dnsimple-app/issues/30854).

## QA

- Visit https://editor-next.swagger.io/
- File > Import URL
- Paste the openapi.yml URL from this branch: https://raw.githubusercontent.com/dnsimple/dnsimple-developer/5fc6f3f9061e59b7bc642eb67338a0baf8f7b75a/content/v2/openapi.yml
- Verify the result