### PR TITLE
Fix /whoami `required` values

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -85,7 +85,7 @@ paths:
                   data:
                     oneOf:
                       - type: object
-                        required: [account]
+                        required: [account, user]
                         properties:
                           account:
                             $ref: '#/components/schemas/Account'
@@ -93,7 +93,7 @@ paths:
                             type: object
                             nullable: true
                       - type: object
-                        required: [user]
+                        required: [account, user]
                         properties:
                           user:
                             $ref: '#/components/schemas/User'


### PR DESCRIPTION
Changes to `required: [account, user]` for /whoami since both keys will always be present in the response.

Follow up to https://github.com/dnsimple/dnsimple-developer/pull/821
Belongs to https://github.com/dnsimple/dnsimple-developer/issues/794