### PR TITLE
Update email forward fixtures

### DIFF
--- a/fixtures/v2/webhooks/email_forward.activate/example.http
+++ b/fixtures/v2/webhooks/email_forward.activate/example.http
@@ -10,4 +10,4 @@ Via: 1.1 vegur
 Total-Route-Time: 1
 Connection: keep-alive
 
-{"data": {"email_forward": {"id": 11587, "to": "test@example.com", "from": "test@hostedzone.com", "domain_id": 322675, "created_at": "2024-11-21T13:21:45Z", "updated_at": "2024-11-21T13:25:51Z", "alias_email": "test@hostedzone.com", "destination_email": "test@example.com"}}, "name": "email_forward.activate", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "1c15eea2-cf3e-4613-9f35-3f4bdd79d231"}
+{"data": {"email_forward": {"id": 11587, "to": "test@example.com", "from": "test@hostedzone.com", "active": true, "domain_id": 322675, "created_at": "2024-11-21T13:21:45Z", "updated_at": "2024-11-21T13:25:51Z", "alias_email": "test@hostedzone.com", "destination_email": "test@example.com"}}, "name": "email_forward.activate", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "1c15eea2-cf3e-4613-9f35-3f4bdd79d231"}

--- a/fixtures/v2/webhooks/email_forward.create/example.http
+++ b/fixtures/v2/webhooks/email_forward.create/example.http
@@ -10,4 +10,4 @@ Content-Length: 460
 Total-Route-Time: 0
 Connection: keep-alive
 
-{"data": {"email_forward": {"id": 30187, "to": "example@example.com", "from": "example@example.zone", "domain_id": 415995, "created_at": "2018-11-07T17:20:39Z", "updated_at": "2018-11-07T17:20:39Z"}}, "name": "email_forward.create", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "46a0c6b7-695c-4650-82d3-c6612599fe76"}
+{"data": {"email_forward": {"id": 30187, "to": "example@example.com", "from": "example@example.zone", "active": true, "domain_id": 415995, "created_at": "2018-11-07T17:20:39Z", "updated_at": "2018-11-07T17:20:39Z", "alias_email": "example@example.zone", "destination_email": "example@example.com"}}, "name": "email_forward.create", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "46a0c6b7-695c-4650-82d3-c6612599fe76"}

--- a/fixtures/v2/webhooks/email_forward.deactivate/example.http
+++ b/fixtures/v2/webhooks/email_forward.deactivate/example.http
@@ -10,4 +10,4 @@ Via: 1.1 vegur
 Total-Route-Time: 1
 Connection: keep-alive
 
-{"data": {"email_forward": {"id": 11587, "to": "test@example.com", "from": "test@hostedzone.com", "domain_id": 322675, "created_at": "2024-11-21T13:21:45Z", "updated_at": "2024-11-21T13:25:51Z", "alias_email": "test@hostedzone.com", "destination_email": "test@example.com"}}, "name": "email_forward.deactivate", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "1c15eea2-cf3e-4613-9f35-3f4bdd79d231"}
+{"data": {"email_forward": {"id": 11587, "to": "test@example.com", "from": "test@hostedzone.com", "active": false, "domain_id": 322675, "created_at": "2024-11-21T13:21:45Z", "updated_at": "2024-11-21T13:25:51Z", "alias_email": "test@hostedzone.com", "destination_email": "test@example.com"}}, "name": "email_forward.deactivate", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "1c15eea2-cf3e-4613-9f35-3f4bdd79d231"}

--- a/fixtures/v2/webhooks/email_forward.delete/example.http
+++ b/fixtures/v2/webhooks/email_forward.delete/example.http
@@ -10,4 +10,4 @@ Content-Type: application/json
 Connect-Time: 0
 Connection: keep-alive
 
-{"data": {"email_forward": {"id": 30187, "to": "example@example.com", "from": ".*@example.zone", "domain_id": 415995, "created_at": "2018-11-07T17:20:39Z", "updated_at": "2018-11-07T17:20:53Z"}}, "name": "email_forward.delete", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "8ab69f9d-1de9-4425-9755-50cc4f10f5a8"}
+{"data": {"email_forward": {"id": 30187, "to": "example@example.com", "from": ".*@example.zone", "active": true, "domain_id": 415995, "created_at": "2018-11-07T17:20:39Z", "updated_at": "2018-11-07T17:20:53Z", "alias_email": ".*@example.zone", "destination_email": "example@example.com"}}, "name": "email_forward.delete", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "8ab69f9d-1de9-4425-9755-50cc4f10f5a8"}

--- a/fixtures/v2/webhooks/email_forward.update/example.http
+++ b/fixtures/v2/webhooks/email_forward.update/example.http
@@ -10,4 +10,4 @@ Via: 1.1 vegur
 Total-Route-Time: 1
 Connection: keep-alive
 
-{"data": {"email_forward": {"id": 30187, "to": "example@example.com", "from": ".*@example.zone", "domain_id": 415995, "created_at": "2018-11-07T17:20:39Z", "updated_at": "2018-11-07T17:20:53Z"}}, "name": "email_forward.update", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "83a53e35-9277-493f-af4d-a06a35167412"}
+{"data": {"email_forward": {"id": 30187, "to": "example@example.com", "from": ".*@example.zone", "active": true, "domain_id": 415995, "created_at": "2018-11-07T17:20:39Z", "updated_at": "2018-11-07T17:20:53Z", "alias_email": ".*@example.zone", "destination_email": "example@example.com"}}, "name": "email_forward.update", "actor": {"id": "1120", "entity": "user", "pretty": "xxxxx@xxxxxxx.xxx"}, "account": {"id": 111, "display": "Personal", "identifier": "xxxxxx"}, "api_version": "v2", "request_identifier": "83a53e35-9277-493f-af4d-a06a35167412"}


### PR DESCRIPTION
Update the email forward fixtures for webhooks based on regenerated samples (The API ones are up-to-date)

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/316