### PR TITLE
Replace `account.add_user` with `account.sso_user_add`

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -5933,10 +5933,10 @@ components:
             - account_invitation.create
             - account_invitation.remove
             - account_invitation.resend
-            - account.add_user
             - account.billing_settings_update
             - account.payment_details_update
             - account.remove_user
+            - account.sso_user_add
             - account.update
             - account.user_invitation_accept
             - account.user_invitation_revoke


### PR DESCRIPTION
This PR replaces `account.add_user` (not fired from the app) with `account.sso_user_add` event.

Related to https://github.com/dnsimple/dnsimple-app/issues/32010#issuecomment-3425523569