### PR TITLE
Restore Google Analytics 4

### DIFF
--- a/layouts/analytics.html
+++ b/layouts/analytics.html
@@ -12,6 +12,17 @@
 </script>
 <% end %>
 
+<% if @config[:google_analytics_4_id] != "" %>
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= @config[:google_analytics_4_id] %>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '<%= @config[:google_analytics_4_id] %>');
+</script>
+<% end %>
+
 <% if @config[:ahrefs_id] != "" %>
   <script src="https://analytics.ahrefs.com/analytics.js" data-key="<%= @config[:ahrefs_id] %>" async></script>
 <% end %>

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -85,6 +85,8 @@ environments:
   default:
     posthog_id: ""
     ahrefs_id: ""
+    google_analytics_4_id: ""
   production:
     ahrefs_id: "UtKH36Rl3tUpIyx+heMxjA"
     posthog_id: "phc_sEjNzo9c8KB8Njj2rXSGhjyyuShmO820Ii2DNYS3igL"
+    google_analytics_4_id: "G-ZNH6WB6RFQ"


### PR DESCRIPTION
Developer site doesn't use Google Tag Manager like dnsimple-app. We use the GA4 property directly.

Belongs to https://github.com/dnsimple/dnsimple-marketing/issues/983

## QA

1. Open the Netlify preview link
2. Verify that the GA4 tag appears in the `<head>`
3. The GA4 tag should not appear when running the app locally