### PR TITLE
Update docs to reference account tokens when pushing a domain to a new account

### DIFF
--- a/content/v2/domains/pushes.markdown
+++ b/content/v2/domains/pushes.markdown
@@ -35,14 +35,14 @@ Initiate a push from the source account `1010` for the `example.com` domain:
 
 Name | Type | Description
 -----|------|------------
-`new_account_token` | `string` | **Required** - The token of the target DNSimple account.
-`new_account_email` | `string` | **Deprecated** - Use `new_account_token` instead. The email address of the target DNSimple account.
+`domain_push_identifier` | `string` | **Required** - The domain push identifier of the target DNSimple account.
+`new_account_email` | `string` | **Deprecated** - Use `domain_push_identifier` instead. The email address of the target DNSimple account.
 
 ##### Example
 
 ~~~json
 {
-  "new_account_token": "token_string_value"
+  "domain_push_identifier": "acc_xxxxxxxx-xxxx-7xxx-xxxx-xxxxxxxxxxxx"
 }
 ~~~
 

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -6921,12 +6921,12 @@ components:
               new_account_email:
                 type: string
                 deprecated: true
-                description: Deprecated - use new_account_token instead
-              new_account_token:
+                description: Deprecated - use domain_push_identifier instead
+              domain_push_identifier:
                 type: string
-                description: The token of the target DNSimple account
+                description: The domain push identifier of the target DNSimple account
             example:
-              new_account_token: token_string_value
+              domain_push_identifier: acc_xxxxxxxx-xxxx-7xxx-xxxx-xxxxxxxxxxxx
     PushAccept:
       description: Attributes required to accept a push
       required: true


### PR DESCRIPTION
This PR updates our docs to use `new_account_token` when pushing a domain and marks `new_account_email` as a deprecated payload.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/2318

### 📋 Deployment Pre/Post tasks

- [ ] PRE: Activate feature flag for all customers.