### PR TITLE
Rename `domain push identifier` to `account identifier`

### DIFF
--- a/content/v2/domains/pushes.markdown
+++ b/content/v2/domains/pushes.markdown
@@ -35,14 +35,14 @@ Initiate a push from the source account `1010` for the `example.com` domain:
 
 Name | Type | Description
 -----|------|------------
-`domain_push_identifier` | `string` | **Required** - The domain push identifier of the target DNSimple account.
-`new_account_email` | `string` | **Deprecated** - Use `domain_push_identifier` instead. The email address of the target DNSimple account.
+`new_account_identifier` | `string` | **Required** - The account identifier of the target DNSimple account.
+`new_account_email` | `string` | **Deprecated** - Use `new_account_identifier` instead. The email address of the target DNSimple account.
 
 ##### Example
 
 ~~~json
 {
-  "domain_push_identifier": "acc_xxxxxxxx-xxxx-7xxx-xxxx-xxxxxxxxxxxx"
+  "new_account_identifier": "xxxxxxxx-xxxx-7xxx-xxxx-xxxxxxxxxxxx"
 }
 ~~~
 

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -6921,12 +6921,12 @@ components:
               new_account_email:
                 type: string
                 deprecated: true
-                description: Deprecated - use domain_push_identifier instead
-              domain_push_identifier:
+                description: Deprecated - use new_account_identifier instead
+              new_account_identifier:
                 type: string
-                description: The domain push identifier of the target DNSimple account
+                description: The account identifier of the target DNSimple account
             example:
-              domain_push_identifier: acc_xxxxxxxx-xxxx-7xxx-xxxx-xxxxxxxxxxxx
+              new_account_identifier: xxxxxxxx-xxxx-7xxx-xxxx-xxxxxxxxxxxx
     PushAccept:
       description: Attributes required to accept a push
       required: true


### PR DESCRIPTION
This PR renames `domain push identifier` to `account identifier`.

No fixtures required to be updated.