### PR TITLE
Granular access tokens can now list zones/domains

### DIFF
--- a/content/v2/domains.md
+++ b/content/v2/domains.md
@@ -22,9 +22,8 @@ Lists the domains in the account.
 GET /:account/domains
 ```
 
-<note>
-When using a [scoped access token](/articles/api-access-token/#scoped-access-tokens) with granular domain permissions, this endpoint returns only the domains the token has access to.
-</note>
+> [!NOTE]
+> When using a [scoped access token](https://support.dnsimple.com/articles/api-access-token/#scoped-access-tokens) with granular domain permissions, this endpoint returns only the domains the token has access to.
 
 ### Parameters
 

--- a/content/v2/zones.md
+++ b/content/v2/zones.md
@@ -22,9 +22,8 @@ Lists the zones in the account.
 GET /:account/zones
 ```
 
-<note>
-When using a [scoped access token](/articles/api-access-token/#scoped-access-tokens) with granular zone permissions, this endpoint returns only the zones the token has access to.
-</note>
+> [!NOTE]
+> When using a [scoped access token](https://support.dnsimple.com/articles/api-access-token/#scoped-access-tokens) with granular zone permissions, this endpoint returns only the zones the token has access to.
 
 ### Parameters
 


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/33294