### PR TITLE
Add fixture for subscription.renew

### DIFF
--- a/fixtures/v2/webhooks/subscription.renew/example.http
+++ b/fixtures/v2/webhooks/subscription.renew/example.http
@@ -1,0 +1,13 @@
+POST /1djlwbe1 HTTP/1.1
+Host: example.com
+Content-Type: application/json
+Total-Route-Time: 7210
+Content-Length: 432
+X-Request-Id: e15222f0-83fd-48ae-ab6f-67c8f3198dcc
+Via: 1.1 vegur
+Connect-Time: 1
+Accept-Encoding: gzip
+User-Agent: DNSimple-Webhook-Notifier/8b16040b4b0e3b18a84c6a300a85119cf638980a
+Connection: keep-alive
+
+{"data": {"subscription": {"id": 11111, "state": "subscribed", "plan_name": "Teams", "created_at": "2018-12-20T13:40:26Z", "updated_at": "2019-04-06T08:57:01Z"}}, "name": "subscription.renew", "actor": {"id": "system", "entity": "dnsimple", "pretty": "support@dnsimple.com"}, "account": {"id": 1111, "display": "xxxxxxxx", "identifier": "xxxxxxxx"}, "api_version": "v2", "request_identifier": "e08f7b64-81b2-454c-a090-ee012cbf2141"}


### PR DESCRIPTION
In https://github.com/dnsimple/dnsimple-go/pull/235 I added support to the remaining events defined by our app, according to our fixtures. What I found, is that `subscription.renew` did not have a proper fixture, just an "error" one.

This PR adds an example fixture as common. 

I actually looked at the other fixture as well, and I can't really determine what the "state failed" means. It seems a successful state. Perhaps we can remove it?

> [!NOTE]
> At some point we need to compare https://github.com/dnsimple/dnsimple-developer/blob/main/content/v2/openapi.yml#L5931 with the list of fixtures we publish, as well with list of events we actually emit from the app.