### PR TITLE
Include support site articles in the support widget

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -127,22 +127,13 @@
     </div>
   </footer>
 
-<% if ENV['NANOC_ENV'] == 'production' %>
-  <script
-    type="text/javascript"
-    src="https://support.dnsimple.com/widget.js"
-    data-dnsimple-current-site-url="https://developer.dnsimple.com"
-    data-dnsimple-getting-started-url="https://developer.dnsimple.com/getting-started/"
-  ></script>
-<% else %>
   <script
     type="text/javascript"
     src="https://support.dnsimple.com/widget.js"
     data-dnsimple-current-site-url=""
     data-dnsimple-getting-started-url="/getting-started/"
-    data-dnsimple-sources='[{"name": "DNSimple Developer", "url": ""}]'
+    data-dnsimple-sources='[{"name": "DNSimple Support", "url": "https://support.dnsimple.com"}, {"name": "DNSimple Developer", "url": ""}]'
   ></script>
-<% end %>
   <script src="/dist/main.js" type="text/javascript" charset="utf-8"></script>
 
 </body>


### PR DESCRIPTION
This PR includes the support site articles in the support widget.

QA: Search for `certificates` @ https://deploy-preview-925--dnsimple-developer.netlify.app/, you should see results from both sites.