### PR TITLE
OpenAPI spec for the Domain Research Status endpoint

### DIFF
--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -262,6 +262,8 @@ paths:
           $ref: '#/components/responses/400'
         '401':
           $ref: '#/components/responses/401'
+        '429':
+          $ref: '#/components/responses/429'
   '/{account}/domains/{domain}/dnssec':
     get:
       description: Gets the DNSSEC status for an existing domain.


### PR DESCRIPTION
Part of #939

Update of the OpenAPI spec of our API with the upcoming _Domain Research Status_ endpoint.