### PR TITLE
Remove deprecated endpoints from spec and docs

### DIFF
--- a/CLIENTS.md
+++ b/CLIENTS.md
@@ -8,35 +8,25 @@ This report tracks endpoint coverage across all DNSimple API clients.
 
 ## Executive Summary
 
-The `openapi.yml` defines **114 operations** in total. Of those, **3 are deprecated and removed** (return `410 Gone`) and are excluded from the coverage comparison, leaving **111 active endpoints** per client.
+The `openapi.yml` defines **111 client-facing operations**.
 
-| Client | Missing (active) | Delta vs. prior report |
-|--------|:----------------:|:----------------------:|
-| Node   |        4         | -5 (was 9)             |
-| Ruby   |        8         | +1 (was 7)             |
-| Go     |        8         | +1 (was 7)             |
-| Python |        8         | +1 (was 7)             |
-| PHP    |       12         | +2 (was 10)            |
-| Java   |       12         | +2 (was 10)            |
-| Elixir |       12         | +2 (was 10)            |
-| C#     |       12         | +2 (was 10)            |
-| Rust   |       13         | +2 (was 11)            |
+| Client | Missing | Delta vs. prior report |
+|--------|:-------:|:----------------------:|
+| Node   |    4    | -5 (was 9)             |
+| Ruby   |    8    | +1 (was 7)             |
+| Go     |    8    | +1 (was 7)             |
+| Python |    8    | +1 (was 7)             |
+| PHP    |   12    | +2 (was 10)            |
+| Java   |   12    | +2 (was 10)            |
+| Elixir |   12    | +2 (was 10)            |
+| C#     |   12    | +2 (was 10)            |
+| Rust   |   13    | +2 (was 11)            |
 
 The deltas account for a newly-surfaced gap: **no client implements `updateZoneNsRecords`** except Node. That endpoint was not tracked in the previous INCONSISTENCIES report.
 
-## Deprecated / removed endpoints (excluded from comparison)
-
-These three operations are flagged `deprecated: true` in `openapi.yml` and respond with `410 Gone`. None of the clients currently ships an implementation for them in source, so they are not counted as gaps.
-
-| operationId             | HTTP                                                                | Note                                     |
-|-------------------------|---------------------------------------------------------------------|------------------------------------------|
-| `getDomainPremiumPrice` | `GET /{account}/registrar/domains/{domain}/premium_price`           | Use `getDomainPrices` instead            |
-| `getWhoisPrivacy`       | `GET /{account}/registrar/domains/{domain}/whois_privacy`           | Use `getDomain` instead                  |
-| `renewWhoisPrivacy`     | `POST /{account}/registrar/domains/{domain}/whois_privacy/renewals` | WHOIS privacy no longer requires renewal |
-
 ## Endpoint Coverage Matrix
 
-Legend: ✅ = implemented, ❌ = missing. `getWhoisPrivacy`, `getDomainPremiumPrice` and `renewWhoisPrivacy` are omitted (see above).
+Legend: ✅ = implemented, ❌ = missing.
 
 | operationId                            | C# | Elixir | Go | Java | Node | PHP | Python | Ruby | Rust |
 |----------------------------------------|:--:|:------:|:--:|:----:|:----:|:---:|:------:|:----:|:----:|
@@ -357,4 +347,3 @@ Missing in:
 
 - The `updateZoneNsRecords` endpoint (`PUT /{account}/zones/{zone}/ns_records`) is present in `openapi.yml` and implemented in the Node client, but was not tracked in the previous INCONSISTENCIES report. It is the only new gap surfaced by this audit.
 - The Node client is now the most complete, having picked up all seven Secondary DNS endpoints and `updateZoneNsRecords`. Its remaining gaps are `domainRestore`, `getDomainRestore`, `batchChangeZoneRecords`, and `queryDnsAnalytics`.
-- The deprecated `getDomainPremiumPrice`, `getWhoisPrivacy` (GET) and `renewWhoisPrivacy` operations were not found in any client's source tree. Clients that previously shipped them (e.g. earlier C# releases) have already removed them.

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -1023,20 +1023,6 @@ paths:
                   data:
                     $ref: '#/components/schemas/DomainCheckResult'
       summary: Check domain
-  '/{account}/registrar/domains/{domain}/premium_price':
-    get:
-      deprecated: true
-      description: 'This endpoint has been deprecated and removed. Use getDomainPrices instead.'
-      parameters:
-        - $ref: '#/components/parameters/Account'
-        - $ref: '#/components/parameters/Domain'
-      operationId: getDomainPremiumPrice
-      tags:
-        - registrar
-      responses:
-        '410':
-          description: This endpoint has been removed.
-      summary: Get domain premium price (deprecated)
   '/{account}/registrar/domains/{domain}/prices':
     get:
       description: Retrieve domain prices.
@@ -1527,19 +1513,6 @@ paths:
           $ref: '#/components/responses/404'
       summary: Disable domain auto-renewal
   '/{account}/registrar/domains/{domain}/whois_privacy':
-    get:
-      deprecated: true
-      description: 'This endpoint has been deprecated and removed. Use getDomain instead.'
-      parameters:
-        - $ref: '#/components/parameters/Account'
-        - $ref: '#/components/parameters/Domain'
-      operationId: getWhoisPrivacy
-      tags:
-        - registrar privacy
-      responses:
-        '410':
-          description: This endpoint has been removed.
-      summary: WHOIS privacy status (deprecated)
     put:
       description: |-
         Enables the WHOIS privacy for the domain.
@@ -1597,20 +1570,6 @@ paths:
         '404':
           $ref: '#/components/responses/404'
       summary: Disable WHOIS privacy
-  '/{account}/registrar/domains/{domain}/whois_privacy/renewals':
-    post:
-      deprecated: true
-      description: 'This endpoint has been deprecated and removed. WHOIS privacy no longer requires renewal.'
-      parameters:
-        - $ref: '#/components/parameters/Account'
-        - $ref: '#/components/parameters/Domain'
-      operationId: renewWhoisPrivacy
-      tags:
-        - registrar privacy
-      responses:
-        '410':
-          description: This endpoint has been removed.
-      summary: Renew WHOIS privacy (deprecated)
   '/{account}/secondary_dns/primaries':
     get:
       summary: List primary servers

--- a/content/v2/registrar.md
+++ b/content/v2/registrar.md
@@ -55,11 +55,6 @@ Responds with [HTTP 400](/v2/#bad-request) if the domain availability cannot be 
 
 Responds with [HTTP 401](/v2/#unauthorized) in case of authentication issues.
 
-## Check domain premium price {#getDomainPremiumPrice}
-
-> [!WARNING] Deprecated since 18 May 2021
-> This endpoint has been deprecated and removed. Use [getDomainPrices](#getDomainPrices) instead.
-
 ## Retrieve domain prices {#getDomainPrices}
 
 Get a domain's price for registration, renewal, and transfer.

--- a/content/v2/registrar/whois-privacy.md
+++ b/content/v2/registrar/whois-privacy.md
@@ -14,11 +14,6 @@ Enable and disable WHOIS privacy on registered domains.
 > Now you can enable WHOIS Privacy protection for any of your domains any time. As long as the domain is registered with us, and the TLD (Top Level Domain) supports WHOIS Privacy, the WHOIS Privacy service will stay enabled unless you disable it.
 
 
-## Retrieve the domain WHOIS privacy {#getWhoisPrivacy}
-
-> [!WARNING]
-> This endpoint has been deprecated and removed. Use [retrieve domain](/v2/domains/#getDomain) instead.
-
 ## Enable WHOIS privacy {#enableWhoisPrivacy}
 
       PUT /:account/registrar/domains/:domain/whois_privacy
@@ -94,8 +89,3 @@ Responds with HTTP 200 if WHOIS privacy is disabled.
 Responds with [HTTP 400](/v2/#bad-request) if WHOIS privacy cannot be disabled.
 
 Responds with [HTTP 401](/v2/#unauthorized) in case of case of authentication issues.
-
-## Renew WHOIS privacy {#renewWhoisPrivacy}
-
-> [!WARNING]
-> This endpoint has been deprecated and removed. WHOIS privacy no longer requires renewal.


### PR DESCRIPTION
These three operations were flagged as deprecated and removed in DEPRECATIONS.md (removal dates 2026-01-14 and 2026-01-20) but were still documented in the OpenAPI spec and registrar pages. Drop the operation definitions from content/v2/openapi.yml, the markdown sections that rendered them, and the corresponding row in CLIENTS.md.