### PR TITLE
Refresh DEPRECATIONS roadmap with latest client status

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -20,9 +20,9 @@ The endpoint `GET /:account/registrar/domains/:domain/premium_price` was used to
 - Python: [Complete](https://github.com/dnsimple/dnsimple-python/pull/483)
 - Rust: [Complete](https://github.com/dnsimple/dnsimple-rust/pull/86)
 
-### 2022-06-01 - Certificate contact_id field
+### 2022-05-17 - Certificate contact_id field
 
-The `contact_id` field in Certificate schema has been deprecated. It is no longer a required field for certificate operations.
+The `contact_id` field in Certificate schema has been deprecated. It is no longer a required field for certificate operations and its value is ignored on input. The field is still emitted on responses for backwards compatibility.
 
 **Removal Date:** N/A
 
@@ -30,7 +30,7 @@ The `contact_id` field in Certificate schema has been deprecated. It is no longe
 
 **Client Status:**
 
-- Ruby: Not started
+- Ruby: Flagged ([#276](https://github.com/dnsimple/dnsimple-ruby/pull/276))
 - Go: Flagged
 - Elixir: Not started
 - Node.js: Not started
@@ -38,13 +38,13 @@ The `contact_id` field in Certificate schema has been deprecated. It is no longe
 - C#: Flagged
 - PHP: Flagged
 - Python: Flagged
-- Rust: Flagged
+- Rust: Flagged (tracked in [dnsimple-rust#105](https://github.com/dnsimple/dnsimple-rust/issues/105))
 
 ### 2021-01-25 - Email forwarding `from` field
 
-The `from` field in Email Forward schema has been renamed to `alias_email` for clarity.
+The `from` field in Email Forward schema has been renamed to `alias_email` for clarity. The server stopped emitting the field on responses on 2026-02-24 and stopped accepting it as input on 2026-03-03. Clients that still expose `from` will see it as null/unset.
 
-**Removal Date:** N/A
+**Removal Date:** 2026-03-03 (Completed)
 
 **Replacement:** Use `alias_email` instead.
 
@@ -52,19 +52,19 @@ The `from` field in Email Forward schema has been renamed to `alias_email` for c
 
 - Ruby: Complete
 - Go: Complete
-- Elixir: Not started
+- Elixir: Flagged (still present in `EmailForward` defstruct)
 - Node.js: Complete
 - Java: Complete
 - C#: Complete
-- PHP: Not started
+- PHP: Flagged (still exposed as `$from` on the `EmailForward` struct)
 - Python: Complete
 - Rust: Complete
 
 ### 2021-01-25 - Email forwarding `to` field
 
-The `to` field in Email Forward schema has been renamed to `destination_email` for clarity.
+The `to` field in Email Forward schema has been renamed to `destination_email` for clarity. The server stopped emitting the field on responses on 2026-02-24 and stopped accepting it as input on 2026-03-03. Clients that still expose `to` will see it as null/unset.
 
-**Removal Date:** N/A
+**Removal Date:** 2026-03-03 (Completed)
 
 **Replacement:** Use `destination_email` instead.
 
@@ -72,11 +72,11 @@ The `to` field in Email Forward schema has been renamed to `destination_email` f
 
 - Ruby: Complete
 - Go: Complete
-- Elixir: Not started
+- Elixir: Flagged (still present in `EmailForward` defstruct)
 - Node.js: Complete
 - Java: Complete
 - C#: Complete
-- PHP: Not started
+- PHP: Flagged (still exposed as `$to` on the `EmailForward` struct)
 - Python: Complete
 - Rust: Complete
 
@@ -120,6 +120,26 @@ The endpoint `POST /:account/registrar/domains/:domain/whois_privacy/renewals` w
 - Python: [Complete](https://github.com/dnsimple/dnsimple-python/pull/484)
 - Rust: [Complete](https://github.com/dnsimple/dnsimple-rust/pull/87)
 
+### 2025-03-19 - DomainCollaborators endpoints
+
+The `/domains/:domain/collaborators` endpoints (list, add, remove) have been removed. The server returns HTTP 410 Gone for all collaborator endpoints.
+
+**Removal Date:** 2025-03-19 (Completed)
+
+**Replacement:** Use the Domain Access Control feature.
+
+**Client Status:**
+
+- Ruby: [Complete](https://github.com/dnsimple/dnsimple-ruby/pull/430) (11.0.0)
+- Go: Complete (5.0.0)
+- Elixir: [Complete](https://github.com/dnsimple/dnsimple-elixir/pull/285) (7.0.0)
+- Node.js: Complete (10.0.0)
+- Java: Complete (3.0.0)
+- C#: [Complete](https://github.com/dnsimple/dnsimple-csharp/pull/182) (0.20.0)
+- PHP: Complete (4.0.0)
+- Python: Complete (5.0.0)
+- Rust: Complete (3.0.0)
+
 ### 2025-11-13 - Domain push `new_account_email` field
 
 The `new_account_email` field in Domain Push request has been deprecated in favor of `new_account_identifier`, which provides more flexibility in identifying the target account.
@@ -130,15 +150,15 @@ The `new_account_email` field in Domain Push request has been deprecated in favo
 
 **Client Status:**
 
-- Ruby: Not started
-- Go: Not started
-- Elixir: Not started
-- Node.js: Not started
-- Java: Not started
-- C#: Not started
-- PHP: Not started
-- Python: Not started
-- Rust: Not started
+- Ruby: [Flagged](https://github.com/dnsimple/dnsimple-ruby/pull/462)
+- Go: [Flagged](https://github.com/dnsimple/dnsimple-go/pull/250) (8.3.0)
+- Elixir: [Flagged](https://github.com/dnsimple/dnsimple-elixir/pull/324)
+- Node.js: [Flagged](https://github.com/dnsimple/dnsimple-node/pull/280)
+- Java: [Flagged](https://github.com/dnsimple/dnsimple-java/pull/243)
+- C#: [Flagged](https://github.com/dnsimple/dnsimple-csharp/pull/230) (1.3.0)
+- PHP: [Flagged](https://github.com/dnsimple/dnsimple-php/pull/161)
+- Python: [Flagged](https://github.com/dnsimple/dnsimple-python/pull/497)
+- Rust: [Flagged](https://github.com/dnsimple/dnsimple-rust/pull/102) (5.3.0)
 
 ## Status Legend
 


### PR DESCRIPTION
## Summary

- Add **DomainCollaborators** removal entry — the server has returned HTTP 410 since 2025-03-19 and every client has shipped the removal; this was missing from the roadmap.
- Refresh **Domain push `new_account_email`** statuses — the coordinated rollout merged on 2026-04-14 across all 9 clients, so they all flip from "Not started" to "Flagged" with PR links.
- Update **EmailForward `from`/`to`** — the server stopped emitting/accepting these on 2026-02-24 and 2026-03-03 respectively; flagged Elixir and PHP, which still expose the legacy fields in their structs.
- Correct **Certificate `contact_id`** deprecation date to 2022-05-17 (the actual server-side cleanup landing date), link the Ruby PR, and reference the open Rust tracking issue (dnsimple/dnsimple-rust#105).

I audited each client's source (not just CHANGELOGs) to confirm the current state of every deprecated field/endpoint. Two gaps surfaced beyond the items above:

- Elixir's `EmailForward` defstruct still includes `from` and `to`; the server no longer returns them, so they will always be `nil`.
- PHP's `EmailForward` struct still defines `$from`/`$to`; same situation.

Both are now flagged in the roadmap.

Pinging relevant team members for visibility:

- cc @ggalmazor — owner of the recent `new_account_email` rollout across all 9 clients
- cc @jacegu — original author of the Certificate `contact_id` deprecation in Ruby
- cc @lokst — merged several of the related client cleanup PRs
