### PR TITLE
Deprecation: Remove contact_id field from Certificate schema

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -30,15 +30,15 @@ The `contact_id` field in Certificate schema has been deprecated. It is no longe
 
 **Client Status:**
 
-- Ruby: In progress
-- Go: In progress
-- Elixir: In progress
-- Node.js: In progress
-- Java: Complete
-- C#: In progress
-- PHP: In progress
-- Python: In progress
-- Rust: In progress
+- Ruby: [In progress](https://github.com/dnsimple/dnsimple-ruby/pull/465)
+- Go: [In progress](https://github.com/dnsimple/dnsimple-go/pull/256)
+- Elixir: [In progress](https://github.com/dnsimple/dnsimple-elixir/pull/328)
+- Node.js: [In progress](https://github.com/dnsimple/dnsimple-node/pull/285)
+- Java: [Complete](https://github.com/dnsimple/dnsimple-java/pull/146)
+- C#: [In progress](https://github.com/dnsimple/dnsimple-csharp/pull/236)
+- PHP: [In progress](https://github.com/dnsimple/dnsimple-php/pull/164)
+- Python: [In progress](https://github.com/dnsimple/dnsimple-python/pull/501)
+- Rust: [In progress](https://github.com/dnsimple/dnsimple-rust/pull/108)
 
 ### 2021-01-25 - Email forwarding `from` field
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -30,15 +30,15 @@ The `contact_id` field in Certificate schema has been deprecated. It is no longe
 
 **Client Status:**
 
-- Ruby: [In progress](https://github.com/dnsimple/dnsimple-ruby/pull/465)
-- Go: [In progress](https://github.com/dnsimple/dnsimple-go/pull/256)
-- Elixir: [In progress](https://github.com/dnsimple/dnsimple-elixir/pull/328)
-- Node.js: [In progress](https://github.com/dnsimple/dnsimple-node/pull/285)
+- Ruby: [Complete](https://github.com/dnsimple/dnsimple-ruby/pull/465)
+- Go: [Complete](https://github.com/dnsimple/dnsimple-go/pull/256)
+- Elixir: [Complete](https://github.com/dnsimple/dnsimple-elixir/pull/328)
+- Node.js: [Complete](https://github.com/dnsimple/dnsimple-node/pull/285)
 - Java: [Complete](https://github.com/dnsimple/dnsimple-java/pull/146)
-- C#: [In progress](https://github.com/dnsimple/dnsimple-csharp/pull/236)
-- PHP: [In progress](https://github.com/dnsimple/dnsimple-php/pull/164)
-- Python: [In progress](https://github.com/dnsimple/dnsimple-python/pull/501)
-- Rust: [In progress](https://github.com/dnsimple/dnsimple-rust/pull/108)
+- C#: [Complete](https://github.com/dnsimple/dnsimple-csharp/pull/236)
+- PHP: [Complete](https://github.com/dnsimple/dnsimple-php/pull/164)
+- Python: [Complete](https://github.com/dnsimple/dnsimple-python/pull/501)
+- Rust: [Complete](https://github.com/dnsimple/dnsimple-rust/pull/108)
 
 ### 2021-01-25 - Email forwarding `from` field
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -22,23 +22,23 @@ The endpoint `GET /:account/registrar/domains/:domain/premium_price` was used to
 
 ### 2022-05-17 - Certificate contact_id field
 
-The `contact_id` field in Certificate schema has been deprecated. It is no longer a required field for certificate operations and its value is ignored on input. The field is still emitted on responses for backwards compatibility.
+The `contact_id` field in Certificate schema has been deprecated. It is no longer a required field for certificate operations and its value is ignored on input.
 
-**Removal Date:** N/A
+**Removal Date:** 2026-04-16
 
 **Replacement:** None. This field is no longer required.
 
 **Client Status:**
 
-- Ruby: Flagged ([#276](https://github.com/dnsimple/dnsimple-ruby/pull/276))
-- Go: Flagged
-- Elixir: Not started
-- Node.js: Not started
+- Ruby: In progress
+- Go: In progress
+- Elixir: In progress
+- Node.js: In progress
 - Java: Complete
-- C#: Flagged
-- PHP: Flagged
-- Python: Flagged
-- Rust: Flagged (tracked in [dnsimple-rust#105](https://github.com/dnsimple/dnsimple-rust/issues/105))
+- C#: In progress
+- PHP: In progress
+- Python: In progress
+- Rust: In progress
 
 ### 2021-01-25 - Email forwarding `from` field
 

--- a/content/use-cases/issue-certificates.md
+++ b/content/use-cases/issue-certificates.md
@@ -49,14 +49,10 @@ When your customer registers a domain through your service, or delegates it for 
 
 [lib/app/dnsimple.rb](https://github.com/dnsimple/dnsimple-api-examples/blob/main/ruby/use_cases/issue_certificates/lib/app/dnsimple.rb#L16)
 
-> [!WARNING] Deprecated since 01 June 2022
-> The `contact_id` field in Certificate schema has been deprecated. It is no longer a required field for certificate operations.
-
 ```ruby
     post '/issue_certificate' do
       certificate_order = App::DnsimpleAdapter.purchase_letsencrypt_certificate(
         parsed_request_body['domain'],
-        App.config.dnsimple['contact_id'],
         name: parsed_request_body['name'],
         alternate_names: parsed_request_body['san']&.split(','),
         auto_renew: parsed_request_body.fetch('auto_renew', true)

--- a/content/v2/certificates.md
+++ b/content/v2/certificates.md
@@ -11,9 +11,6 @@ excerpt: This page documents the DNSimple certificates API v2.
 
 ## Certificate attributes {#certificate-attributes}
 
-> [!WARNING] Deprecated since 01 June 2022
-> The `contact_id` field in Certificate schema has been deprecated. It is no longer a required field for certificate operations.
-
 Please refer to the definition of the `Certificate` data type in [our OpenAPI documentation](/v2/openapi.yml).
 
 

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -3688,7 +3688,6 @@ components:
       required:
         - id
         - domain_id
-        - contact_id
         - name
         - common_name
         - years
@@ -3706,9 +3705,6 @@ components:
           type: integer
         domain_id:
           type: integer
-        contact_id:
-          type: integer
-          deprecated: true
         name:
           type: string
         common_name:


### PR DESCRIPTION
## Summary

This PR tracks the work to complete the deprecation and removal of the `contact_id` field from the Certificate schema.

See [DEPRECATIONS.md](https://github.com/dnsimple/dnsimple-developer/blob/main/DEPRECATIONS.md) for full details.

### Background

The `contact_id` field in Certificate schema was deprecated on **2022-05-17**. It is no longer a required field for certificate operations and its value is ignored on input. The field is being removed from the OpenAPI specification and all client libraries.

### Checklist

- [x] Update developer site
- [x] Update OpenAPI
- [x] Update clients

### Client Status

- Ruby: https://github.com/dnsimple/dnsimple-ruby/pull/465
- Go: https://github.com/dnsimple/dnsimple-go/pull/256
- Elixir: https://github.com/dnsimple/dnsimple-elixir/pull/328
- Node.js: https://github.com/dnsimple/dnsimple-node/pull/285
- Java: https://github.com/dnsimple/dnsimple-java/pull/146 (2023-03-03)
- C#: https://github.com/dnsimple/dnsimple-csharp/pull/236
- PHP: https://github.com/dnsimple/dnsimple-php/pull/164
- Python: https://github.com/dnsimple/dnsimple-python/pull/501
- Rust: https://github.com/dnsimple/dnsimple-rust/pull/108