### PR TITLE
Deprecation: Remove Email Forward from and to fields

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -52,11 +52,11 @@ The `from` field in Email Forward schema has been renamed to `alias_email` for c
 
 - Ruby: Complete
 - Go: Complete
-- Elixir: Flagged (still present in `EmailForward` defstruct)
+- Elixir: [Complete](https://github.com/dnsimple/dnsimple-elixir/pull/TBD)
 - Node.js: Complete
 - Java: Complete
 - C#: Complete
-- PHP: Flagged (still exposed as `$from` on the `EmailForward` struct)
+- PHP: [Complete](https://github.com/dnsimple/dnsimple-php/pull/TBD)
 - Python: Complete
 - Rust: Complete
 
@@ -72,11 +72,11 @@ The `to` field in Email Forward schema has been renamed to `destination_email` f
 
 - Ruby: Complete
 - Go: Complete
-- Elixir: Flagged (still present in `EmailForward` defstruct)
+- Elixir: [Complete](https://github.com/dnsimple/dnsimple-elixir/pull/TBD)
 - Node.js: Complete
 - Java: Complete
 - C#: Complete
-- PHP: Flagged (still exposed as `$to` on the `EmailForward` struct)
+- PHP: [Complete](https://github.com/dnsimple/dnsimple-php/pull/TBD)
 - Python: Complete
 - Rust: Complete
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -52,11 +52,11 @@ The `from` field in Email Forward schema has been renamed to `alias_email` for c
 
 - Ruby: Complete
 - Go: Complete
-- Elixir: [Complete](https://github.com/dnsimple/dnsimple-elixir/pull/TBD)
+- Elixir: [Complete](https://github.com/dnsimple/dnsimple-elixir/pull/329)
 - Node.js: Complete
 - Java: Complete
 - C#: Complete
-- PHP: [Complete](https://github.com/dnsimple/dnsimple-php/pull/TBD)
+- PHP: [Complete](https://github.com/dnsimple/dnsimple-php/pull/165)
 - Python: Complete
 - Rust: Complete
 
@@ -72,11 +72,11 @@ The `to` field in Email Forward schema has been renamed to `destination_email` f
 
 - Ruby: Complete
 - Go: Complete
-- Elixir: [Complete](https://github.com/dnsimple/dnsimple-elixir/pull/TBD)
+- Elixir: [Complete](https://github.com/dnsimple/dnsimple-elixir/pull/329)
 - Node.js: Complete
 - Java: Complete
 - C#: Complete
-- PHP: [Complete](https://github.com/dnsimple/dnsimple-php/pull/TBD)
+- PHP: [Complete](https://github.com/dnsimple/dnsimple-php/pull/165)
 - Python: Complete
 - Rust: Complete
 


### PR DESCRIPTION
## Summary

This PR tracks the completion of the deprecation and removal of the `from` and `to` fields in the Email Forward schema for the remaining clients.

See [DEPRECATIONS.md](https://github.com/dnsimple/dnsimple-developer/blob/main/DEPRECATIONS.md) for full details.

### Background

The `from` field was renamed to `alias_email`, and the `to` field was renamed to `destination_email`, both deprecated on 2021-01-25. The server stopped emitting the fields on 2026-02-24 and stopped accepting them as input on 2026-03-03. The OpenAPI specification has already removed both fields.

Most clients had already been updated. This PR tracks completion of the remaining two: Elixir and PHP.

### Checklist

- [x] Update developer site
- [x] Update clients

### Client Status

- Ruby: Complete
- Go: Complete
- Elixir: https://github.com/dnsimple/dnsimple-elixir/pull/329
- Node.js: Complete
- Java: Complete
- C#: Complete
- PHP: https://github.com/dnsimple/dnsimple-php/pull/165
- Python: Complete
- Rust: Complete