### PR TITLE
Cross-link checkDomain and Domain Research endpoints

### DIFF
--- a/content/v2/domains/research.md
+++ b/content/v2/domains/research.md
@@ -18,6 +18,9 @@ Research a domain name for availability and registration status information.
 
 This endpoint provides information about a domain's availability status, including whether it's available for registration, already registered, or has other restrictions that prevent registration.
 
+> [!NOTE]
+> This endpoint is designed for high-volume domain availability lookups and requires dedicated paid access. [Contact sales](https://dnsimple.com/sales) to request access. If you only need to check a domain's state before issuing a registration or transfer, use the [Check domain](/v2/registrar/#checkDomain) endpoint instead, which is rate-limited and intended for low-volume use.
+
 ~~~
 GET /:account/domains/research/status
 ~~~

--- a/content/v2/registrar.md
+++ b/content/v2/registrar.md
@@ -12,7 +12,7 @@ excerpt: This page documents the DNSimple registry/registrar API v2.
 ## Check domain {#checkDomain}
 
 > [!WARNING]
-> This API endpoint has stricter limits in place to avoid a high volume of requests. This endpoint should be used only to check a domain's state before issuing a domain registration or a domain transfer. For other use cases, we recommend using other services like [Domainr](https://domainr.com/).
+> This API endpoint has stricter rate limits in place to avoid a high volume of requests. It should be used only to check a domain's state before issuing a domain registration or a domain transfer. For high-volume availability lookups, use the [Domain Research API](/v2/domains/research/#getDomainsResearchStatus) instead, which is designed for that use case and requires dedicated paid access. [Contact sales](https://dnsimple.com/sales) to request access.
 
 Checks a domain name for availability.
 


### PR DESCRIPTION
## Summary

The `checkDomain` endpoint previously suggested third-party services for high-volume availability lookups.

This update replaces that suggestion with a pointer to our own Research API, which is purpose-built for that use case but requires dedicated paid access. The Domain Research endpoint now also documents the access requirement (with a link to sales) and cross-links back to `checkDomain` for callers who only need low-volume checks before a registration or transfer.

## Test plan

- [x] Build the site locally and verify both pages render the new callouts correctly.
- [x] Confirm the cross-links resolve to the right anchors (`#checkDomain` and `#getDomainsResearchStatus`).
- [x] Confirm the sales link points to https://dnsimple.com/sales.