### PR TITLE
Add styling for blockquotes

### DIFF
--- a/content/assets/css/_colorscheme.scss
+++ b/content/assets/css/_colorscheme.scss
@@ -89,6 +89,12 @@ pre {
   border: 1px solid var(--surface2);
 }
 
+blockquote {
+  background: var(--surface1);
+  border-left-color: var(--primary);
+  color: var(--element1);
+}
+
 input {
   background: var(--elementInverse);
   color: var(--element1);

--- a/content/assets/css/_typography.scss
+++ b/content/assets/css/_typography.scss
@@ -41,7 +41,7 @@ h5 {
   font-size: 15px;
 }
 
-p, pre, table {
+p, pre, table, blockquote {
   margin: 0 0 math.div($base-unit, 1.5) 0;
 }
 
@@ -74,5 +74,19 @@ pre {
     padding: 0;
     background: transparent;
     font-family: $font-monospace;
+  }
+}
+
+blockquote {
+  padding: 1rem 1.25rem;
+  border-left: 4px solid;
+  border-radius: 4px;
+
+  > :first-child {
+    margin-top: 0;
+  }
+
+  > :last-child {
+    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
Adds styling for simple blockquotes (without NOTE, or INFO).

<img width="437" height="215" alt="Screenshot 2026-04-23 at 12 12 46" src="https://github.com/user-attachments/assets/583fa91f-eb33-46e7-b95c-76f937905674" />

<img width="437" height="215" alt="Screenshot 2026-04-23 at 12 13 03" src="https://github.com/user-attachments/assets/f76d9f71-accb-4454-8576-2952d6eeb045" />
