### PR TITLE
Update CLI repo links to dnsimple/cli

### DIFF
--- a/content/cli.md
+++ b/content/cli.md
@@ -67,14 +67,14 @@ dnsimple --version
 If you are developing or testing the CLI itself, install from source with Go 1.25 or newer:
 
 ```shell
-go install github.com/dnsimple/dnsimple-cli/cmd/dnsimple@latest
+go install github.com/dnsimple/cli/cmd/dnsimple@latest
 ```
 
 Or build from a local checkout:
 
 ```shell
-git clone https://github.com/dnsimple/dnsimple-cli.git
-cd dnsimple-cli
+git clone https://github.com/dnsimple/cli.git
+cd cli
 make build
 ```
 


### PR DESCRIPTION
## Summary

- Update references in `content/cli.md` from `dnsimple/dnsimple-cli` to `dnsimple/cli` to match the renamed GitHub repository
- Adjusts the `go install` path, `git clone` URL, and the `cd` directory accordingly

## Test plan

- [x] Verify rendered CLI install instructions point to the correct repo