### PR TITLE
Document Domain Research access, usage visibility, and monthly cap

### DIFF
--- a/content/v2/domains/research.md
+++ b/content/v2/domains/research.md
@@ -25,6 +25,20 @@ This endpoint provides information about a domain's availability status, includi
 GET /:account/domains/research/status
 ~~~
 
+### Access
+
+Access is gated by the **Domain Research** subscription on the account.
+
+Access tokens used with this endpoint must include the `domain_research_read` scope.
+
+### Usage visibility
+
+The account's month-to-date Domain Research request count is shown in the **API Limits & Usage** card on the API tokens page in the DNSimple app.
+
+### Monthly request cap
+
+This endpoint has a monthly request cap that depends on your subscription. Once an account reaches its cap, further requests in the same calendar month respond with [HTTP 429](#errors) and a `Retry-After` header indicating when the cap resets.
+
 ### Parameters
 
 Name | Type | Description
@@ -76,3 +90,5 @@ Name | Type | Description
 Responds with [HTTP 400](/v2/#bad-request) if the domain research request is invalid.
 
 Responds with [HTTP 401](/v2/#unauthorized) in case of authentication issues.
+
+Responds with [HTTP 429](/v2/#too-many-requests) if the account has reached its [monthly request cap](#monthly-request-cap). The response includes a `Retry-After` header set to the time at which the cap resets.

--- a/fixtures/v2/api/getDomainsResearchStatus/cap-exceeded.http
+++ b/fixtures/v2/api/getDomainsResearchStatus/cap-exceeded.http
@@ -1,0 +1,16 @@
+HTTP/1.1 429 Too Many Requests
+server: nginx
+date: Mon, 25 May 2026 14:22:18 GMT
+content-type: application/json; charset=utf-8
+content-length: 41
+retry-after: Mon, 01 Jun 2026 00:00:00 GMT
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2391
+x-ratelimit-reset: 1779976938
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: 9d4a3b27-1f55-4b8c-9e6d-2a8c4b8e9b0a
+x-runtime: 0.012345
+strict-transport-security: max-age=63072000
+
+{"message":"Monthly request cap reached"}


### PR DESCRIPTION
Tightens `content/v2/domains/research.md` so a developer reading the page
can tell, without leaving it, that they need the Domain Research
subscription and the `domain_research_read` scope, where their
month-to-date usage shows up in-app, and what the cap-exceeded response
looks like.

The cap number is intentionally not published — only that a cap exists
and depends on the subscription. The shared `/v2/#too-many-requests`
reference already covers the body shape and `X-RateLimit-*` headers, so
the cap-specific `Retry-After` is documented in narrative only; see the
issue notes for the OpenAPI `$ref` reasoning.

Fixes #1021
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2779


## :mag: QA

- **Render the Domain Research page locally**
  - `bundle install && yarn install`
  - `yarn live`
  - Open <http://localhost:3000/v2/domains/research/>
  - Verify the new **Access**, **Usage visibility**, and **Monthly request cap** sections render under the existing private-beta banner.
  - Verify the HTTP 429 line in **Errors** links to <http://localhost:3000/v2/#too-many-requests> and the in-page link to **Monthly request cap** anchors correctly.


## :clipboard: Deployment Pre/Post tasks

N / A


## :shipit: Deployment Verification

- [ ] production: Verify a successful deploy