### PR TITLE
Document OAuth token-endpoint error codes and statuses

### DIFF
--- a/content/v2/oauth.md
+++ b/content/v2/oauth.md
@@ -78,6 +78,14 @@ You'll receive a JSON response. If the request is successful, the response will 
 <%= pretty_print_fixture("/api/oauthAccessToken/success.http") %>
 ```
 
+##### Error Responses
+
+If the request fails, you'll receive a JSON response with an `error` code and an `error_description`. The HTTP status and the `error` value depend on the failure:
+
+`invalid_grant`   | **HTTP 400**. The authorization `code` is unknown or expired, or it was not issued to the supplied `client_id`.
+`invalid_client`  | **HTTP 401**. Client authentication failed, for example an incorrect `client_secret`.
+`invalid_request` | **HTTP 400**. The request is otherwise invalid, for example an unsupported `grant_type` or a `redirect_uri` / `state` that does not match the original authorization request.
+
 ### Step 3 - API authentication
 
 The access token allows you to execute authenticated API requests on a behalf of the user account. When you'd like to make API calls to DNSimple, simply include the authorization header with each request.

--- a/content/v2/openapi.yml
+++ b/content/v2/openapi.yml
@@ -156,7 +156,7 @@ paths:
                   account_id:
                     type: integer
         '400':
-          description: Invalid or expired code, invalid client credentials, or redirect_uri/state mismatch.
+          description: Invalid or expired authorization code, client_id mismatch, unsupported grant_type, or redirect_uri/state mismatch.
           content:
             application/json:
               schema:
@@ -164,7 +164,20 @@ paths:
                 properties:
                   error:
                     type: string
-                    description: Error code per OAuth 2.0 spec (e.g. invalid_request).
+                    description: Error code per OAuth 2.0 spec (invalid_grant or invalid_request).
+                  error_description:
+                    type: string
+                    description: Human-readable description of the error.
+        '401':
+          description: Client authentication failed, for example an incorrect client_secret.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error code per OAuth 2.0 spec (invalid_client).
                   error_description:
                     type: string
                     description: Human-readable description of the error.


### PR DESCRIPTION
## Summary

Documents the observable error-code and status changes to the OAuth token endpoint (`POST /v2/oauth/access_token`).

The error/status are:

- `invalid_grant` (400): the authorization `code` is unknown or expired, or it was not issued to the supplied `client_id` (previously `invalid_request` / 400).
- `invalid_client` (401): client authentication failed, for example an incorrect `client_secret` (previously `invalid_request` / 400; the 401 status is new for this endpoint).
- `invalid_request` (400): unsupported `grant_type`, or a `redirect_uri` / `state` that does not match the authorization request (unchanged).

The `200` happy-path response is bit-identical, so no fixture changes were needed.
