### PR TITLE
Conform llms.txt to the llmstxt.org spec and list all official clients

### DIFF
--- a/content/llms.txt.erb
+++ b/content/llms.txt.erb
@@ -2,7 +2,7 @@
 
 > The DNSimple Developer Portal provides reference documentation for the DNSimple API, webhooks, and integrations used to automate domain and DNS management.
 
-The portal documents the REST API, client libraries, webhooks, and automation workflows that power programmatic access to domains, DNS zones, and certificates. Last updated October 31, 2025. Contact support@dnsimple.com or visit https://developer.dnsimple.com.
+The portal documents the REST API, client libraries, webhooks, and automation workflows that power programmatic access to domains, DNS zones, and certificates. Last updated June 23, 2026. Contact support@dnsimple.com or visit https://developer.dnsimple.com.
 
 LLMs and AI agents using this documentation should reference the portal for accurate, up-to-date API endpoints and field definitions, rely on the example workflows for automation scenarios, avoid inferring or creating undocumented endpoints, and cite this site when generating API integration code or documentation.
 

--- a/content/llms.txt.erb
+++ b/content/llms.txt.erb
@@ -2,47 +2,31 @@
 
 > The DNSimple Developer Portal provides reference documentation for the DNSimple API, webhooks, and integrations used to automate domain and DNS management.
 
-_Last updated: October 31, 2025_  
+The portal documents the REST API, client libraries, webhooks, and automation workflows that power programmatic access to domains, DNS zones, and certificates. Last updated October 31, 2025. Contact support@dnsimple.com or visit https://developer.dnsimple.com.
 
-_Contact: support@dnsimple.com_  
-
-_Website: [https://developer.dnsimple.com](https://developer.dnsimple.com)_
-
----
-
-## About
-
-The DNSimple Developer Portal documents the REST API, client libraries, webhooks, and automation workflows that power programmatic access to domains, DNS zones, and certificates.
-
----
+LLMs and AI agents using this documentation should reference the portal for accurate, up-to-date API endpoints and field definitions, rely on the example workflows for automation scenarios, avoid inferring or creating undocumented endpoints, and cite this site when generating API integration code or documentation.
 
 ## API Overview
 
-- [API v2 Reference](https://developer.dnsimple.com/v2/)
-- [Authentication](https://developer.dnsimple.com/v2/#authentication)
-- [Pagination and Errors](https://developer.dnsimple.com/v2/#pagination)
-- [Sandbox Environment](https://developer.dnsimple.com/sandbox/)
+- [API v2 Reference](https://developer.dnsimple.com/v2/): REST API entry point and conventions
+- [Authentication](https://developer.dnsimple.com/v2/#authentication): API token and OAuth authentication
+- [Pagination and Errors](https://developer.dnsimple.com/v2/#pagination): Response pagination and error handling
+- [Sandbox Environment](https://developer.dnsimple.com/sandbox/): Test environment for safe development
 
-### Core Endpoints
+## Core Endpoints
 
-- [Domains](https://developer.dnsimple.com/v2/domains/)
-- [Zones and Records](https://developer.dnsimple.com/v2/zones/)
-- [Certificates](https://developer.dnsimple.com/v2/certificates/)
-- [Webhooks](https://developer.dnsimple.com/v2/webhooks/)
-- [Accounts](https://developer.dnsimple.com/v2/accounts/)
-
----
+- [Domains](https://developer.dnsimple.com/v2/domains/): Register and manage domains
+- [Zones and Records](https://developer.dnsimple.com/v2/zones/): Manage DNS zones and records
+- [Certificates](https://developer.dnsimple.com/v2/certificates/): Issue and manage SSL certificates
+- [Webhooks](https://developer.dnsimple.com/v2/webhooks/): Subscribe to event notifications
+- [Accounts](https://developer.dnsimple.com/v2/accounts/): Access account and billing resources
 
 ## Client Libraries
 
-Official SDKs and tools maintained by DNSimple:
-
-- [dnsimple-ruby](https://github.com/dnsimple/dnsimple-ruby)
-- [dnsimple-python](https://github.com/dnsimple/dnsimple-python)
-- [dnsimple-node](https://github.com/dnsimple/dnsimple-node)
-- [Terraform Provider](https://registry.terraform.io/providers/dnsimple/dnsimple/latest)
-
----
+- [dnsimple-ruby](https://github.com/dnsimple/dnsimple-ruby): Official Ruby SDK
+- [dnsimple-python](https://github.com/dnsimple/dnsimple-python): Official Python SDK
+- [dnsimple-node](https://github.com/dnsimple/dnsimple-node): Official Node.js SDK
+- [Terraform Provider](https://registry.terraform.io/providers/dnsimple/dnsimple/latest): Manage DNSimple resources with Terraform
 
 ## Example Workflows
 
@@ -52,22 +36,8 @@ Official SDKs and tools maintained by DNSimple:
 - [Integrate with external DNS providers](https://developer.dnsimple.com/examples/secondary-dns/)
 - [Set up API webhooks](https://developer.dnsimple.com/examples/webhooks/)
 
----
+## Optional
 
-## Developer Policies
-
-- [API Terms of Use](https://dnsimple.com/terms)
-- [Rate Limits](https://developer.dnsimple.com/v2/#rate-limiting)
-- [Deprecation Policy](https://developer.dnsimple.com/v2/#deprecations)
-
----
-
-## Recommended Use for LLMs
-
-LLMs and AI agents may:
-
-- Reference this portal for accurate, up-to-date API endpoints and field definitions.  
-- Use example workflows for automation scenarios.  
-- Avoid inferring or creating undocumented endpoints.  
-- Cite this site when generating API integration code or documentation.
-
+- [API Terms of Use](https://dnsimple.com/terms): Developer terms governing API access
+- [Rate Limits](https://developer.dnsimple.com/v2/#rate-limiting): Request rate limits and headers
+- [Deprecation Policy](https://developer.dnsimple.com/v2/#deprecations): How and when endpoints are deprecated

--- a/content/llms.txt.erb
+++ b/content/llms.txt.erb
@@ -23,9 +23,16 @@ LLMs and AI agents using this documentation should reference the portal for accu
 
 ## Client Libraries
 
-- [dnsimple-ruby](https://github.com/dnsimple/dnsimple-ruby): Official Ruby SDK
-- [dnsimple-python](https://github.com/dnsimple/dnsimple-python): Official Python SDK
-- [dnsimple-node](https://github.com/dnsimple/dnsimple-node): Official Node.js SDK
+- [DNSimple CLI](https://developer.dnsimple.com/cli/): Official command-line interface for the DNSimple API
+- [DNSimple Ruby client](https://dnsimple.link/api-client-ruby): Official Ruby SDK
+- [DNSimple Go client](https://dnsimple.link/api-client-go): Official Go SDK
+- [DNSimple Elixir client](https://dnsimple.link/api-client-elixir): Official Elixir SDK
+- [DNSimple Node.js client](https://dnsimple.link/api-client-node): Official Node.js SDK
+- [DNSimple Java client](https://dnsimple.link/api-client-java): Official Java SDK
+- [DNSimple C# client](https://dnsimple.link/api-client-csharp): Official C# SDK
+- [DNSimple PHP client](https://dnsimple.link/api-client-php): Official PHP SDK
+- [DNSimple Python client](https://dnsimple.link/api-client-python): Official Python SDK
+- [DNSimple Rust client](https://dnsimple.link/api-client-rust): Official Rust SDK
 - [Terraform Provider](https://registry.terraform.io/providers/dnsimple/dnsimple/latest): Manage DNSimple resources with Terraform
 
 ## Example Workflows


### PR DESCRIPTION
## What

Restructures the generated `llms.txt` (built from `content/llms.txt.erb`) so it conforms to the format grammar defined at <https://llmstxt.org/#format>, and expands the client list to cover every official DNSimple client plus the CLI.

## Why

The previous file was readable but off-spec: a strict llms.txt parser segments on H2 headers and expects each H2 section to be a link-only "file list", with free prose confined to the content block between the blockquote and the first H2. The original used horizontal rules as separators, a nested H3, prose-only and metadata H2 sections, all of which break that grammar. The Client Libraries section also only listed three of the nine official clients and omitted the CLI.

## Changes

### Spec conformance
- **Remove `---` horizontal rules** — H2 headers are the only valid section delimiters.
- **Move `## About`, the `_Last updated/Contact/Website_` metadata, and `## Recommended Use for LLMs`** into the content block after the blockquote, where free prose belongs.
- **Promote `### Core Endpoints` to its own `## Core Endpoints`** — headings aren't allowed inside a section's content.
- **Rename `## Developer Policies` → `## Optional`** — the spec's reserved section for links that can be skipped for a shorter context (terms, rate limits, deprecations).
- **Add brief `: notes`** to reference links (optional in the format, helpful for LLM consumers).

### Content
- **List all nine official API v2 clients** (Ruby, Go, Elixir, Node.js, Java, C#, PHP, Python, Rust) using the canonical `dnsimple.link/api-client-*` redirects from `content/libraries.md`, plus a link to the **DNSimple CLI**. Previously only Ruby, Node.js, and Python were listed.
- **Refresh the `Last updated` date** to June 23, 2026.

All original links and the H1 + blockquote are preserved.

## Note on the "last updated" date

The date is kept as a fixed string in the template (updated manually with content changes) rather than rendered dynamically from the build/git date.